### PR TITLE
feat: enhance RipStatisticsPageClient with detailed card checklist an…

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -44,6 +44,14 @@ from backend.db.services.explore_rip_statistics_service import (
     ExploreRipStatisticsTargetsError,
     get_rip_statistics_targets_payload,
 )
+from backend.db.services.pokemon_sets_catalog_service import (
+    PokemonSetsCatalogError,
+    get_pokemon_sets_catalog_payload,
+)
+from backend.db.services.pokemon_set_cards_service import (
+    PokemonSetCardsError,
+    get_pokemon_set_cards_payload,
+)
 
 
 app = FastAPI(title="EVR Collection API")
@@ -562,3 +570,39 @@ def profile_public_get(
 def profile_tcgs_get():
     payload, status = get_tcg_options()
     return JSONResponse(content=payload, status_code=status)
+
+
+@app.get("/tcgs/pokemon/sets")
+def get_pokemon_sets_catalog():
+    """Return Pokemon set summary metadata for the public Sets catalog page."""
+    try:
+        return get_pokemon_sets_catalog_payload()
+    except PokemonSetsCatalogError as exc:
+        return JSONResponse(
+            content={"message": exc.message, "code": exc.code},
+            status_code=exc.status_code,
+        )
+    except Exception:
+        logger.exception("/tcgs/pokemon/sets unexpected error")
+        return JSONResponse(
+            content={"message": "Unable to load Pokemon sets", "code": "POKEMON_SETS_CATALOG_FAILED"},
+            status_code=500,
+        )
+
+
+@app.get("/tcgs/pokemon/sets/{set_id}/cards")
+def get_pokemon_set_cards(set_id: str):
+    """Return checklist cards for a single Pokemon set."""
+    try:
+        return get_pokemon_set_cards_payload(set_id=set_id)
+    except PokemonSetCardsError as exc:
+        return JSONResponse(
+            content={"message": exc.message, "code": exc.code},
+            status_code=exc.status_code,
+        )
+    except Exception:
+        logger.exception("/tcgs/pokemon/sets/%s/cards unexpected error", set_id)
+        return JSONResponse(
+            content={"message": "Unable to load Pokemon set cards", "code": "POKEMON_SET_CARDS_FAILED"},
+            status_code=500,
+        )

--- a/backend/calculations/evr/__init__.py
+++ b/backend/calculations/evr/__init__.py
@@ -19,6 +19,7 @@ from .derived_metrics import (
     build_pack_simulation_summary,
     print_derived_metrics_summary,
 )
+from .hit_value_metrics import compute_hit_value_metrics, compute_simulated_set_value
 
 __all__ = [
     "compute_pack_decision_metrics",
@@ -32,4 +33,6 @@ __all__ = [
     "PackSimulationSummary",
     "build_pack_simulation_summary",
     "print_derived_metrics_summary",
+    "compute_hit_value_metrics",
+    "compute_simulated_set_value",
 ]

--- a/backend/calculations/evr/derived_metrics.py
+++ b/backend/calculations/evr/derived_metrics.py
@@ -1556,6 +1556,8 @@ def compute_all_derived_metrics(
     total_pack_ev: Optional[float] = None,
     hit_ev: Optional[float] = None,
     hit_cards_count: Optional[int] = None,
+    hit_value_metrics: Optional[Dict[str, Any]] = None,
+    set_value_metrics: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Compute the full derived metrics suite from simulation outputs.
 
@@ -1588,6 +1590,10 @@ def compute_all_derived_metrics(
         Optional sum of hit-card EV contributions (for EV composition).
     hit_cards_count:
         Optional count of unique hit cards (for composition context).
+    hit_value_metrics:
+        Optional realized hit-only value metrics from the simulation counters.
+    set_value_metrics:
+        Optional one-copy simulated set value metrics for the priced universe.
 
     Returns
     -------
@@ -1643,6 +1649,8 @@ def compute_all_derived_metrics(
         "pack_decision_metrics": pack_metrics,
         "chase_dependency_metrics": chase_metrics,
         "ev_composition_metrics": ev_comp_metrics,
+        "hit_value_metrics": dict(hit_value_metrics or {}),
+        "set_value_metrics": dict(set_value_metrics or {}),
         "session_metrics": sess_metrics,
         "packs_to_hit_metrics": pth_metrics,
         "pack_score": pack_score_payload,

--- a/backend/calculations/evr/hit_value_metrics.py
+++ b/backend/calculations/evr/hit_value_metrics.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Dict, Optional
+
+import pandas as pd
+
+from backend.calculations.utils.rarity_classification import (
+    is_excluded_from_chase_metrics,
+    is_hit_rarity,
+    normalize_rarity_key,
+)
+
+
+def _coerce_float(value: Any) -> Optional[float]:
+    if value is None or value == "":
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if pd.isna(parsed):
+        return None
+    return parsed
+
+
+def _coerce_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _first_present(row: Mapping[str, Any], *field_names: str) -> Any:
+    for field_name in field_names:
+        if field_name in row and row.get(field_name) not in (None, ""):
+            return row.get(field_name)
+    return None
+
+
+def compute_hit_value_metrics(
+    *,
+    rarity_pull_counts: Mapping[str, Any],
+    rarity_value_totals: Mapping[str, Any],
+    packs_simulated: int,
+    config: Any,
+) -> Dict[str, Any]:
+    """Compute hit-only realized value metrics from simulation rarity counters.
+
+    The current simulation output tracks pulled card events by rarity, not exact
+    per-pack hit membership for every engine path. Therefore ``hit_pull_rate`` is
+    persisted as hit cards pulled per simulated pack. Pattern overlays are
+    excluded from all hit-only totals.
+    """
+    hit_cards_pulled = 0
+    total_hit_value = 0.0
+
+    for rarity, raw_count in (rarity_pull_counts or {}).items():
+        rarity_text = str(rarity or "").strip()
+        if not rarity_text:
+            continue
+        if not is_hit_rarity(rarity_text, config):
+            continue
+        if is_excluded_from_chase_metrics(rarity_text, config):
+            continue
+
+        count = _coerce_int(raw_count)
+        if count <= 0:
+            continue
+
+        total_value = _coerce_float((rarity_value_totals or {}).get(rarity))
+        if total_value is None:
+            total_value = 0.0
+
+        hit_cards_pulled += count
+        total_hit_value += float(total_value)
+
+    average_hit_value = (total_hit_value / hit_cards_pulled) if hit_cards_pulled > 0 else None
+    hit_ev_per_pack = (total_hit_value / packs_simulated) if packs_simulated > 0 else None
+    hit_pull_rate = (hit_cards_pulled / packs_simulated) if packs_simulated > 0 else None
+
+    return {
+        "total_value_hit_cards_pulled": float(total_hit_value),
+        "average_hit_value": average_hit_value,
+        "hit_ev_per_pack": hit_ev_per_pack,
+        "hit_pull_rate": hit_pull_rate,
+        "hit_cards_pulled": int(hit_cards_pulled),
+    }
+
+
+def _row_pattern_rank(row: Mapping[str, Any]) -> int:
+    special_type = str(_first_present(row, "Special Type", "special_type") or "")
+    pattern_key = str(_first_present(row, "pattern_key") or normalize_rarity_key(special_type))
+    if pattern_key in {"poke_ball_pattern", "pokeball_pattern", "master_ball_pattern", "masterball_pattern"}:
+        return 1
+
+    text_blob = " ".join(
+        str(_first_present(row, field) or "")
+        for field in ("printing_type", "printing", "edition", "variant")
+    ).lower()
+    if any(token in text_blob for token in ("reverse", "foil", "parallel", "stamped")):
+        return 1
+    return 0
+
+
+def _fallback_unique_card_key(row: Mapping[str, Any], set_id: str) -> str:
+    name = normalize_rarity_key(_first_present(row, "Card Name", "card_name") or "")
+    number = normalize_rarity_key(_first_present(row, "Card Number", "card_number") or "")
+    rarity = normalize_rarity_key(_first_present(row, "Rarity", "rarity", "rarity_raw") or "")
+    return f"{set_id}:{number}:{name}:{rarity}"
+
+
+def compute_simulated_set_value(
+    dataframe: pd.DataFrame,
+    *,
+    config: Any,
+    set_id: str,
+) -> Dict[str, Any]:
+    """Compute one-copy simulated set value from the priced simulation universe.
+
+    This is the current "simulated set value" until a future canonical
+    unique_cards table can provide checklist-perfect identity and pricing.
+    Variant/pattern rows are collapsed by canonical card id when available.
+    """
+    _ = config
+    if not isinstance(dataframe, pd.DataFrame) or dataframe.empty:
+        return {"simulated_set_value": 0.0, "simulated_set_value_card_count": 0}
+
+    rows_by_identity: Dict[str, tuple[int, float]] = {}
+
+    for row in dataframe.to_dict(orient="records"):
+        price = _coerce_float(
+            _first_present(row, "base_price", "Price ($)", "market_price", "price_used")
+        )
+        if price is None:
+            continue
+
+        identity = _first_present(row, "canonical_card_id", "card_id")
+        if identity is None:
+            identity = _fallback_unique_card_key(row, set_id)
+        identity_key = str(identity).strip()
+        if not identity_key:
+            identity_key = _fallback_unique_card_key(row, set_id)
+
+        rank = _row_pattern_rank(row)
+        previous = rows_by_identity.get(identity_key)
+        if previous is None or rank < previous[0]:
+            rows_by_identity[identity_key] = (rank, float(price))
+
+    return {
+        "simulated_set_value": float(sum(price for _, price in rows_by_identity.values())),
+        "simulated_set_value_card_count": int(len(rows_by_identity)),
+    }

--- a/backend/calculations/utils/rarity_classification.py
+++ b/backend/calculations/utils/rarity_classification.py
@@ -12,14 +12,32 @@ Key principle:
 """
 
 
-from typing import Set
 import re
+import unicodedata
+from collections.abc import Mapping
+from typing import Any, Set
 
 import pandas as pd
 
 
 RARITY_KEY_SEPARATOR_PATTERN = re.compile(r"[\s-]+")
 RARITY_KEY_DUPLICATE_SEPARATOR_PATTERN = re.compile(r"_+")
+DEFAULT_CHASE_METRICS_EXCLUDED_RARITY_KEYS = frozenset(
+    {
+        "poke_ball_pattern",
+        "pokeball_pattern",
+        "master_ball_pattern",
+        "masterball_pattern",
+    }
+)
+
+
+def _strip_accents(value: str) -> str:
+    return "".join(
+        char
+        for char in unicodedata.normalize("NFKD", value)
+        if not unicodedata.combining(char)
+    )
 
 
 def normalize_rarity_string(rarity_raw: str) -> str:
@@ -35,7 +53,7 @@ def normalize_rarity_string(rarity_raw: str) -> str:
     str
         Normalized rarity (lowercase, stripped whitespace).
     """
-    return str(rarity_raw).lower().strip()
+    return _strip_accents(str(rarity_raw)).lower().strip()
 
 
 def normalize_rarity_key(rarity_raw: str) -> str:
@@ -88,6 +106,12 @@ def is_hit_rarity(rarity_raw: str, config) -> bool:
     
     normalized = normalize_rarity_string(rarity_raw)
     mapped_group = config.RARITY_MAPPING.get(normalized)
+    if mapped_group is None:
+        normalized_key = normalize_rarity_key(rarity_raw)
+        mapped_group = {
+            normalize_rarity_key(raw_key): group
+            for raw_key, group in config.RARITY_MAPPING.items()
+        }.get(normalized_key)
     return mapped_group == 'hits'
 
 
@@ -118,7 +142,14 @@ def get_rarity_group(rarity_raw: str, config) -> str:
         )
     
     normalized = normalize_rarity_string(rarity_raw)
-    return config.RARITY_MAPPING.get(normalized)
+    mapped_group = config.RARITY_MAPPING.get(normalized)
+    if mapped_group is not None:
+        return mapped_group
+    normalized_key = normalize_rarity_key(rarity_raw)
+    return {
+        normalize_rarity_key(raw_key): group
+        for raw_key, group in config.RARITY_MAPPING.items()
+    }.get(normalized_key)
 
 
 def is_hit_classification(classification_key: str) -> bool:
@@ -128,26 +159,64 @@ def is_hit_classification(classification_key: str) -> bool:
     return normalize_rarity_key(classification_key) in RECOGNIZED_PATTERN_BUCKETS
 
 
-def is_hit_row(row: pd.Series, config) -> bool:
-    """Classify a card row as hit/non-hit using normalized classification first, then raw rarity."""
-    if is_hit_classification(row.get("classification_key", "")):
-        return True
+def _get_field(card_or_row: Any, *field_names: str) -> Any:
+    if card_or_row is None:
+        return None
+    if isinstance(card_or_row, Mapping):
+        for field_name in field_names:
+            if field_name in card_or_row:
+                return card_or_row.get(field_name)
+        return None
+    get = getattr(card_or_row, "get", None)
+    if callable(get):
+        for field_name in field_names:
+            value = get(field_name, None)
+            if value is not None:
+                return value
+    for field_name in field_names:
+        if hasattr(card_or_row, field_name):
+            return getattr(card_or_row, field_name)
+    return None
 
-    return is_hit_rarity(row.get("Rarity", ""), config)
+
+def is_hit_row(row: pd.Series, config) -> bool:
+    """Classify a card row for hit-only metrics, including chase exclusions."""
+    return is_hit_card(row, config)
 
 
 def get_chase_metrics_excluded_rarities(config) -> Set[str]:
-    """Return normalized raw rarities excluded from chase/hit-derived metrics."""
+    """Return normalized raw rarities excluded from chase/hit-derived metrics.
+
+    Pattern overlays are excluded by default from hit-only metrics even when an
+    era config maps them to ``hits`` for pack-simulation behavior.
+    """
     configured = getattr(config, "CHASE_METRICS_EXCLUDED_RARITIES", set())
-    if configured is None:
-        return set()
-    return {normalize_rarity_string(rarity) for rarity in configured}
+    configured_keys = set()
+    if configured is not None:
+        configured_keys = {normalize_rarity_key(rarity) for rarity in configured}
+    return set(DEFAULT_CHASE_METRICS_EXCLUDED_RARITY_KEYS) | configured_keys
 
 
 def is_excluded_from_chase_metrics(rarity_raw: str, config) -> bool:
     """Check if a raw rarity should be excluded from hit/chase-derived metrics."""
-    normalized = normalize_rarity_string(rarity_raw)
+    normalized = normalize_rarity_key(rarity_raw)
     return normalized in get_chase_metrics_excluded_rarities(config)
+
+
+def is_hit_card(card_or_row: Any, config) -> bool:
+    """Classify a card-like object as a hit using config mapping plus exclusions."""
+    rarity_raw = _get_field(card_or_row, "Rarity", "rarity", "rarity_raw", "rarity_bucket")
+    classification_key = _get_field(card_or_row, "classification_key", "pattern_key", "aggregation_key")
+
+    if classification_key and is_hit_classification(str(classification_key)):
+        return not (
+            is_excluded_from_chase_metrics(str(classification_key), config)
+            or is_excluded_from_chase_metrics(str(rarity_raw or ""), config)
+        )
+
+    if not is_hit_rarity(rarity_raw or "", config):
+        return False
+    return not is_excluded_from_chase_metrics(rarity_raw or "", config)
 
 
 def filter_card_ev_by_hits(card_ev_contributions: dict, df, config) -> tuple:
@@ -210,9 +279,7 @@ def filter_card_ev_by_hits(card_ev_contributions: dict, df, config) -> tuple:
         first_rows_by_card_number = df_indexed.groupby("_card_key", sort=False).first()
         hit_status_by_card_number = {}
         for card_key, row in first_rows_by_card_number.iterrows():
-            is_hit = bool(is_hit_row(row, config))
-            if is_hit and is_excluded_from_chase_metrics(row.get("Rarity", ""), config):
-                is_hit = False
+            is_hit = bool(is_hit_card(row, config))
             hit_status_by_card_number[str(card_key)] = is_hit
     else:
         # Legacy: build name-based index
@@ -225,9 +292,7 @@ def filter_card_ev_by_hits(card_ev_contributions: dict, df, config) -> tuple:
         hit_status_by_name = {}
         for normalized_name, (_, row) in zip(name_col, df.iterrows()):
             if normalized_name not in hit_status_by_name:
-                is_hit = bool(is_hit_row(row, config))
-                if is_hit and is_excluded_from_chase_metrics(row.get("Rarity", ""), config):
-                    is_hit = False
+                is_hit = bool(is_hit_card(row, config))
                 hit_status_by_name[normalized_name] = is_hit
 
     for card_key, ev_value in card_ev_contributions.items():

--- a/backend/db/migrations/022_add_hit_value_and_set_value_metrics.sql
+++ b/backend/db/migrations/022_add_hit_value_and_set_value_metrics.sql
@@ -1,0 +1,111 @@
+-- Migration 022: add simulated set value and realized hit-only metrics.
+--
+-- These columns are nullable and additive. Set value here is the current
+-- "simulated set value" from the priced simulation universe, not the future
+-- canonical checklist value from a unique_cards table.
+
+ALTER TABLE IF EXISTS public.simulation_derived_metrics
+    ADD COLUMN IF NOT EXISTS simulated_set_value NUMERIC,
+    ADD COLUMN IF NOT EXISTS simulated_set_value_card_count INTEGER,
+    ADD COLUMN IF NOT EXISTS average_hit_value NUMERIC,
+    ADD COLUMN IF NOT EXISTS hit_ev_per_pack NUMERIC,
+    ADD COLUMN IF NOT EXISTS hit_pull_rate NUMERIC,
+    ADD COLUMN IF NOT EXISTS hit_cards_pulled INTEGER;
+
+DO $$
+DECLARE
+    metric_cols text[] := ARRAY[
+        'simulated_set_value',
+        'simulated_set_value_card_count',
+        'average_hit_value',
+        'hit_ev_per_pack',
+        'hit_pull_rate',
+        'hit_cards_pulled'
+    ];
+    view_name text;
+    missing_cols text[] := ARRAY[]::text[];
+    col_name text;
+    base_cols_select text;
+    appended_select text;
+    current_view_def text;
+    create_sql text;
+BEGIN
+    FOREACH view_name IN ARRAY ARRAY[
+        'explore_rip_statistics_latest',
+        'simulation_latest_by_target'
+    ] LOOP
+        IF to_regclass(format('public.%I', view_name)) IS NULL THEN
+            RAISE NOTICE 'View public.% does not exist; skipping metric passthrough', view_name;
+            CONTINUE;
+        END IF;
+
+        missing_cols := ARRAY[]::text[];
+
+        FOREACH col_name IN ARRAY metric_cols LOOP
+            IF NOT EXISTS (
+                SELECT 1
+                FROM information_schema.columns c
+                WHERE c.table_schema = 'public'
+                  AND c.table_name = view_name
+                  AND c.column_name = col_name
+            ) THEN
+                missing_cols := array_append(missing_cols, col_name);
+            END IF;
+        END LOOP;
+
+        IF coalesce(array_length(missing_cols, 1), 0) = 0 THEN
+            RAISE NOTICE 'public.% already exposes hit/set value metrics', view_name;
+            CONTINUE;
+        END IF;
+
+        SELECT string_agg(format('base.%I', c.column_name), E',\n    ' ORDER BY c.ordinal_position)
+        INTO base_cols_select
+        FROM information_schema.columns c
+        WHERE c.table_schema = 'public'
+          AND c.table_name = view_name;
+
+        SELECT string_agg(format('sdm.%I AS %I', c, c), E',\n    ')
+        INTO appended_select
+        FROM unnest(missing_cols) AS c;
+
+        -- Important: pg_get_viewdef can return a trailing semicolon.
+        -- That semicolon is invalid when the view definition is wrapped inside FROM (...).
+        SELECT regexp_replace(
+            pg_get_viewdef(format('public.%I', view_name)::regclass, true),
+            ';\s*$',
+            ''
+        )
+        INTO current_view_def;
+
+        create_sql := format(
+$view$
+CREATE OR REPLACE VIEW public.%I AS
+SELECT
+    %s,
+    %s
+FROM (
+%s
+) AS base
+LEFT JOIN (
+    SELECT
+        calculation_run_id,
+        max(simulated_set_value) AS simulated_set_value,
+        max(simulated_set_value_card_count) AS simulated_set_value_card_count,
+        max(average_hit_value) AS average_hit_value,
+        max(hit_ev_per_pack) AS hit_ev_per_pack,
+        max(hit_pull_rate) AS hit_pull_rate,
+        max(hit_cards_pulled) AS hit_cards_pulled
+    FROM public.simulation_derived_metrics
+    GROUP BY calculation_run_id
+) AS sdm
+    ON sdm.calculation_run_id = base.calculation_run_id
+$view$,
+            view_name,
+            base_cols_select,
+            appended_select,
+            current_view_def
+        );
+
+        EXECUTE create_sql;
+    END LOOP;
+END $$;

--- a/backend/db/repositories/calculation_runs_repository.py
+++ b/backend/db/repositories/calculation_runs_repository.py
@@ -10,6 +10,12 @@ from backend.db.clients.supabase_client import supabase
 
 
 DERIVED_METRIC_FIELDS: List[str] = [
+    "simulated_set_value",
+    "simulated_set_value_card_count",
+    "average_hit_value",
+    "hit_ev_per_pack",
+    "hit_pull_rate",
+    "hit_cards_pulled",
     "hit_ev",
     "non_hit_ev",
     "hit_ev_share",
@@ -683,6 +689,12 @@ def create_simulation_derived_metrics(run_id: Any, derived: Optional[Mapping[str
 
     payload = {
         "calculation_run_id": _require_present(run_id, "calculation_run_id"),
+        "simulated_set_value": _coerce_optional_float(derived.get("simulated_set_value")),
+        "simulated_set_value_card_count": _coerce_optional_int(derived.get("simulated_set_value_card_count")),
+        "average_hit_value": _coerce_optional_float(derived.get("average_hit_value")),
+        "hit_ev_per_pack": _coerce_optional_float(derived.get("hit_ev_per_pack")),
+        "hit_pull_rate": _coerce_optional_float(derived.get("hit_pull_rate")),
+        "hit_cards_pulled": _coerce_optional_int(derived.get("hit_cards_pulled")),
         "hit_ev": _coerce_optional_float(derived.get("hit_ev")),
         "non_hit_ev": _coerce_optional_float(derived.get("non_hit_ev")),
         "hit_ev_share": _coerce_optional_float(derived.get("hit_ev_share")),

--- a/backend/db/services/calculation_run_persistence_service.py
+++ b/backend/db/services/calculation_run_persistence_service.py
@@ -303,6 +303,12 @@ def _build_flat_derived_metrics_payload(derived: Mapping[str, Any]) -> dict[str,
         ev_comp = _extract_required_nested_mapping(derived, "ev_composition_metrics", "derived")
         chase = _extract_required_nested_mapping(derived, "chase_dependency_metrics", "derived")
         pack_score = _extract_required_nested_mapping(derived, "pack_score", "derived")
+        hit_value_metrics = derived.get("hit_value_metrics")
+        if not isinstance(hit_value_metrics, Mapping):
+            hit_value_metrics = {}
+        set_value_metrics = derived.get("set_value_metrics")
+        if not isinstance(set_value_metrics, Mapping):
+            set_value_metrics = {}
         total_pack_ev = _require_float(
             _first_present(ev_comp, ("total_pack_ev",))
             if _first_present(ev_comp, ("total_pack_ev",)) is not None
@@ -410,6 +416,38 @@ def _build_flat_derived_metrics_payload(derived: Mapping[str, Any]) -> dict[str,
         )
 
     return {
+        "simulated_set_value": _coerce_optional_float(
+            _first_present(set_value_metrics, ("simulated_set_value",)),
+            "derived.set_value_metrics.simulated_set_value",
+        ),
+        "simulated_set_value_card_count": (
+            _require_int(
+                _first_present(set_value_metrics, ("simulated_set_value_card_count",)),
+                "derived.set_value_metrics.simulated_set_value_card_count",
+            )
+            if _first_present(set_value_metrics, ("simulated_set_value_card_count",)) is not None
+            else None
+        ),
+        "average_hit_value": _coerce_optional_float(
+            _first_present(hit_value_metrics, ("average_hit_value",)),
+            "derived.hit_value_metrics.average_hit_value",
+        ),
+        "hit_ev_per_pack": _coerce_optional_float(
+            _first_present(hit_value_metrics, ("hit_ev_per_pack",)),
+            "derived.hit_value_metrics.hit_ev_per_pack",
+        ),
+        "hit_pull_rate": _coerce_optional_float(
+            _first_present(hit_value_metrics, ("hit_pull_rate",)),
+            "derived.hit_value_metrics.hit_pull_rate",
+        ),
+        "hit_cards_pulled": (
+            _require_int(
+                _first_present(hit_value_metrics, ("hit_cards_pulled",)),
+                "derived.hit_value_metrics.hit_cards_pulled",
+            )
+            if _first_present(hit_value_metrics, ("hit_cards_pulled",)) is not None
+            else None
+        ),
         "hit_ev": _require_float(ev_comp.get("hit_ev"), "derived.ev_composition_metrics.hit_ev"),
         "non_hit_ev": _require_float(ev_comp.get("non_hit_ev"), "derived.ev_composition_metrics.non_hit_ev"),
         "hit_ev_share": _coerce_share_or_zero(

--- a/backend/db/services/explore_page_service.py
+++ b/backend/db/services/explore_page_service.py
@@ -101,6 +101,15 @@ _RIP_SUMMARY_SUPPLEMENT_FIELDS = (
     "derived_metric_version",
 )
 
+_OPTIONAL_HIT_SET_VALUE_SUMMARY_FIELDS = (
+    "simulated_set_value",
+    "simulated_set_value_card_count",
+    "average_hit_value",
+    "hit_ev_per_pack",
+    "hit_pull_rate",
+    "hit_cards_pulled",
+)
+
 
 def _to_optional_str(value: Any) -> Optional[str]:
     if value is None:
@@ -1129,6 +1138,11 @@ def _missing_required_fields(row: Dict[str, Any], required_fields: tuple[str, ..
     return [field for field in required_fields if field not in row]
 
 
+def _ensure_optional_summary_fields(summary: Dict[str, Any]) -> None:
+    for field in _OPTIONAL_HIT_SET_VALUE_SUMMARY_FIELDS:
+        summary.setdefault(field, None)
+
+
 def _lookup_latest_run_from_calculation_runs(target_type: str, target_id: str) -> str:
     """Fallback latest run lookup when canonical latest view is unavailable."""
     run_result = (
@@ -1496,6 +1510,7 @@ def get_explore_page_payload(
     if requested_target_type == "set":
         _populate_biggest_upside_metrics_for_set(summary, requested_target_id, warnings, sources)
         _populate_relative_average_return_score_for_set(summary, requested_target_id, warnings, sources)
+    _ensure_optional_summary_fields(summary)
 
     # Distribution bins (optional, separate query)
     distribution_started = time.perf_counter()
@@ -2553,6 +2568,7 @@ def get_explore_page_payload(
     if requested_target_type == "set":
         _populate_biggest_upside_metrics_for_set(summary, requested_target_id, warnings, sources)
         _populate_relative_average_return_score_for_set(summary, requested_target_id, warnings, sources)
+    _ensure_optional_summary_fields(summary)
 
     # Distribution bins (optional, separate query)
     distribution_started = time.perf_counter()

--- a/backend/db/services/explore_page_service.py
+++ b/backend/db/services/explore_page_service.py
@@ -236,6 +236,79 @@ def _to_optional_float(value: Any) -> Optional[float]:
     return parsed
 
 
+def _load_history_trend_rows(
+    requested_target_type: str,
+    requested_target_id: str,
+    history_trend_limit: int,
+) -> tuple[List[Dict[str, Any]], str]:
+    """Load history trend rows while tolerating partial/legacy view schemas."""
+
+    select_attempts = [
+        (
+            "snapshot_date,mean_value_to_cost_ratio,median_value_to_cost_ratio,"
+            "simulated_mean_pack_value_vs_pack_cost,simulated_median_pack_value_vs_pack_cost,"
+            "pack_cost,mean_value,median_value,run_created_at,calculation_run_id,p95_value_to_cost_ratio",
+            "OK_CANONICAL",
+        ),
+        (
+            "snapshot_date,mean_value_to_cost_ratio,median_value_to_cost_ratio,"
+            "simulated_mean_pack_value_vs_pack_cost,simulated_median_pack_value_vs_pack_cost,"
+            "pack_cost,mean_value,median_value,run_created_at,calculation_run_id",
+            "OK_CANONICAL_NO_P95",
+        ),
+        (
+            "snapshot_date,mean_value_to_cost_ratio,median_value_to_cost_ratio,"
+            "simulated_mean_pack_value_vs_pack_cost,simulated_median_pack_value_vs_pack_cost,"
+            "run_created_at,calculation_run_id",
+            "OK_CANONICAL_CORE",
+        ),
+        (
+            "snapshot_date,simulated_mean_pack_value_vs_pack_cost,"
+            "simulated_median_pack_value_vs_pack_cost,run_created_at,calculation_run_id,"
+            "p95_value_to_cost_ratio",
+            "OK_LEGACY_P95",
+        ),
+        (
+            "snapshot_date,simulated_mean_pack_value_vs_pack_cost,"
+            "simulated_median_pack_value_vs_pack_cost,run_created_at,calculation_run_id",
+            "OK_LEGACY",
+        ),
+    ]
+
+    last_exception: Optional[Exception] = None
+
+    for select_columns, source_key in select_attempts:
+        try:
+            history_result = (
+                public_read_client.table("calculation_history_trend")
+                .select(select_columns)
+                .eq("target_type", requested_target_type)
+                .eq("target_id", requested_target_id)
+                .order("snapshot_date", desc=True)
+                .limit(history_trend_limit)
+                .execute()
+            )
+            history_rows = history_result.data if history_result and history_result.data else []
+            history_rows.sort(
+                key=lambda row: (str(row.get("snapshot_date") or ""), str(row.get("run_created_at") or ""))
+            )
+            return history_rows, source_key
+        except Exception as exc:
+            last_exception = exc
+            logger.warning(
+                "[explore-page] calculation_history_trend select fallback failed target_type=%s target_id=%s source=%s: %s",
+                requested_target_type,
+                requested_target_id,
+                source_key,
+                exc,
+            )
+
+    if last_exception:
+        raise last_exception
+
+    return [], "FAILED"
+
+
 def _load_set_maps() -> tuple[Dict[str, Any], Dict[str, str]]:
     from backend.constants.tcg.pokemon.megaEvolutionEra.setMap import (
         SET_ALIAS_MAP as mega_alias_map,
@@ -1494,57 +1567,22 @@ def get_explore_page_payload(
     history_started = time.perf_counter()
     history_trend: List[Dict[str, Any]] = []
     try:
-        history_result = (
-            public_read_client.table("calculation_history_trend")
-            .select(
-                "snapshot_date,simulated_mean_pack_value_vs_pack_cost,"
-                "simulated_median_pack_value_vs_pack_cost,run_created_at,calculation_run_id,"
-                "p95_value_to_cost_ratio"
-            )
-            .eq("target_type", requested_target_type)
-            .eq("target_id", requested_target_id)
-            .order("snapshot_date", desc=True)
-            .limit(history_trend_limit)
-            .execute()
+        history_rows, history_source = _load_history_trend_rows(
+            requested_target_type=requested_target_type,
+            requested_target_id=requested_target_id,
+            history_trend_limit=history_trend_limit,
         )
-        history_rows = history_result.data if history_result and history_result.data else []
-        history_rows.sort(key=lambda row: (str(row.get("snapshot_date") or ""), str(row.get("run_created_at") or "")))
         history_trend = history_rows
-        sources["calculation_history_trend"] = "OK"
+        sources["calculation_history_trend"] = history_source
     except Exception as exc:
         logger.warning(
-            "[explore-page] calculation_history_trend failed (with p95) target_type=%s target_id=%s: %s – retrying without p95",
+            "[explore-page] calculation_history_trend failed target_type=%s target_id=%s: %s",
             requested_target_type,
             requested_target_id,
             exc,
         )
-        # Fallback: retry without p95_value_to_cost_ratio in case the view does not expose that column yet.
-        try:
-            history_result_fallback = (
-                public_read_client.table("calculation_history_trend")
-                .select(
-                    "snapshot_date,simulated_mean_pack_value_vs_pack_cost,"
-                    "simulated_median_pack_value_vs_pack_cost,run_created_at,calculation_run_id"
-                )
-                .eq("target_type", requested_target_type)
-                .eq("target_id", requested_target_id)
-                .order("snapshot_date", desc=True)
-                .limit(history_trend_limit)
-                .execute()
-            )
-            history_rows_fb = history_result_fallback.data if history_result_fallback and history_result_fallback.data else []
-            history_rows_fb.sort(key=lambda row: (str(row.get("snapshot_date") or ""), str(row.get("run_created_at") or "")))
-            history_trend = history_rows_fb
-            sources["calculation_history_trend"] = "OK_NO_P95"
-        except Exception as exc2:
-            logger.warning(
-                "[explore-page] calculation_history_trend fallback also failed target_type=%s target_id=%s: %s",
-                requested_target_type,
-                requested_target_id,
-                exc2,
-            )
-            warnings.append("Failed to load historical trend")
-            sources["calculation_history_trend"] = "FAILED"
+        warnings.append("Failed to load historical trend")
+        sources["calculation_history_trend"] = "FAILED"
     history_ms = (time.perf_counter() - history_started) * 1000
 
     total_ms = (time.perf_counter() - total_started) * 1000
@@ -2586,57 +2624,22 @@ def get_explore_page_payload(
     history_started = time.perf_counter()
     history_trend: List[Dict[str, Any]] = []
     try:
-        history_result = (
-            public_read_client.table("calculation_history_trend")
-            .select(
-                "snapshot_date,simulated_mean_pack_value_vs_pack_cost,"
-                "simulated_median_pack_value_vs_pack_cost,run_created_at,calculation_run_id,"
-                "p95_value_to_cost_ratio"
-            )
-            .eq("target_type", requested_target_type)
-            .eq("target_id", requested_target_id)
-            .order("snapshot_date", desc=True)
-            .limit(history_trend_limit)
-            .execute()
+        history_rows, history_source = _load_history_trend_rows(
+            requested_target_type=requested_target_type,
+            requested_target_id=requested_target_id,
+            history_trend_limit=history_trend_limit,
         )
-        history_rows = history_result.data if history_result and history_result.data else []
-        history_rows.sort(key=lambda row: (str(row.get("snapshot_date") or ""), str(row.get("run_created_at") or "")))
         history_trend = history_rows
-        sources["calculation_history_trend"] = "OK"
+        sources["calculation_history_trend"] = history_source
     except Exception as exc:
         logger.warning(
-            "[explore-page] calculation_history_trend failed (with p95) target_type=%s target_id=%s: %s – retrying without p95",
+            "[explore-page] calculation_history_trend failed target_type=%s target_id=%s: %s",
             requested_target_type,
             requested_target_id,
             exc,
         )
-        # Fallback: retry without p95_value_to_cost_ratio in case the view does not expose that column yet.
-        try:
-            history_result_fallback = (
-                public_read_client.table("calculation_history_trend")
-                .select(
-                    "snapshot_date,simulated_mean_pack_value_vs_pack_cost,"
-                    "simulated_median_pack_value_vs_pack_cost,run_created_at,calculation_run_id"
-                )
-                .eq("target_type", requested_target_type)
-                .eq("target_id", requested_target_id)
-                .order("snapshot_date", desc=True)
-                .limit(history_trend_limit)
-                .execute()
-            )
-            history_rows_fb = history_result_fallback.data if history_result_fallback and history_result_fallback.data else []
-            history_rows_fb.sort(key=lambda row: (str(row.get("snapshot_date") or ""), str(row.get("run_created_at") or "")))
-            history_trend = history_rows_fb
-            sources["calculation_history_trend"] = "OK_NO_P95"
-        except Exception as exc2:
-            logger.warning(
-                "[explore-page] calculation_history_trend fallback also failed target_type=%s target_id=%s: %s",
-                requested_target_type,
-                requested_target_id,
-                exc2,
-            )
-            warnings.append("Failed to load historical trend")
-            sources["calculation_history_trend"] = "FAILED"
+        warnings.append("Failed to load historical trend")
+        sources["calculation_history_trend"] = "FAILED"
     history_ms = (time.perf_counter() - history_started) * 1000
 
     total_ms = (time.perf_counter() - total_started) * 1000

--- a/backend/db/services/pokemon_set_cards_service.py
+++ b/backend/db/services/pokemon_set_cards_service.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import logging
+import re
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from backend.db.clients.supabase_client import public_read_client
+
+logger = logging.getLogger(__name__)
+
+
+class PokemonSetCardsError(Exception):
+    def __init__(self, status_code: int, message: str, code: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
+        self.code = code
+
+
+def _to_optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _to_optional_float(value: Any) -> Optional[float]:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _normalize_name(value: Any) -> Optional[str]:
+    raw = _to_optional_str(value)
+    if not raw:
+        return None
+    return re.sub(r"\s+", " ", raw).strip().lower()
+
+
+def _normalize_number(value: Any) -> Optional[str]:
+    raw = _to_optional_str(value)
+    if not raw:
+        return None
+    return raw.replace(" ", "").lower()
+
+
+def _resolve_card_number(card: Dict[str, Any]) -> Optional[str]:
+    return (
+        _to_optional_str(card.get("card_number"))
+        or _to_optional_str(card.get("collector_number"))
+        or _to_optional_str(card.get("number"))
+    )
+
+
+def _resolve_image_small(card: Dict[str, Any]) -> Optional[str]:
+    return (
+        _to_optional_str(card.get("image_small_url"))
+        or _to_optional_str(card.get("small_image_url"))
+        or _to_optional_str(card.get("image_url"))
+    )
+
+
+def _resolve_image_large(card: Dict[str, Any]) -> Optional[str]:
+    return (
+        _to_optional_str(card.get("image_large_url"))
+        or _to_optional_str(card.get("large_image_url"))
+        or _to_optional_str(card.get("image_url"))
+    )
+
+
+def _resolve_market_price(card: Dict[str, Any]) -> Optional[float]:
+    for key in ("market_price", "estimated_market_price"):
+        value = _to_optional_float(card.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _card_quality_score(card: Dict[str, Any]) -> int:
+    score = 0
+    if _resolve_image_small(card) or _resolve_image_large(card):
+        score += 3
+    if _resolve_market_price(card) is not None:
+        score += 2
+    if _to_optional_str(card.get("rarity")):
+        score += 1
+    if _resolve_card_number(card):
+        score += 1
+    if _to_optional_str(card.get("name")):
+        score += 1
+    return score
+
+
+def _build_dedupe_key(set_id: str, card: Dict[str, Any]) -> str:
+    # Prefer API-native card identity when available.
+    pokemon_tcg_api_id = _to_optional_str(card.get("pokemon_tcg_api_id"))
+    if pokemon_tcg_api_id:
+        return f"pokemon_tcg_api_id:{pokemon_tcg_api_id}"
+
+    normalized_number = _normalize_number(_resolve_card_number(card))
+    normalized_name = _normalize_name(card.get("name"))
+    if normalized_number and normalized_name:
+        return f"set_id+card_number+normalized_name:{set_id}:{normalized_number}:{normalized_name}"
+
+    if normalized_number:
+        return f"set_id+card_number:{set_id}:{normalized_number}"
+
+    if normalized_name:
+        return f"set_id+normalized_name:{set_id}:{normalized_name}"
+
+    return f"cards.id:{_to_optional_str(card.get('id')) or ''}"
+
+
+def _sort_key(card: Dict[str, Any]) -> Tuple[int, Any, Any, str]:
+    number = _to_optional_str(card.get("card_number"))
+    if number:
+        compact = number.replace(" ", "")
+        front = compact.split("/", 1)[0]
+        numeric_match = re.fullmatch(r"(\d+)([a-zA-Z]*)", front)
+        if numeric_match:
+            suffix = numeric_match.group(2).lower()
+            return (0, int(numeric_match.group(1)), suffix, compact.lower())
+
+        mixed_match = re.search(r"(\d+)", front)
+        if mixed_match:
+            return (1, int(mixed_match.group(1)), front.lower(), compact.lower())
+
+        return (2, front.lower(), "", compact.lower())
+
+    name = _to_optional_str(card.get("name")) or ""
+    return (3, name.lower(), "", "")
+
+
+def get_pokemon_set_cards_payload(set_id: str) -> Dict[str, Any]:
+    total_started = time.perf_counter()
+    resolved_set_id = _to_optional_str(set_id)
+    if not resolved_set_id:
+        raise PokemonSetCardsError(
+            status_code=400,
+            message="set_id is required",
+            code="POKEMON_SET_ID_REQUIRED",
+        )
+
+    try:
+        set_result = (
+            public_read_client.table("sets")
+            .select("id,name,canonical_key")
+            .eq("id", resolved_set_id)
+            .maybe_single()
+            .execute()
+        )
+        set_row = set_result.data if set_result else None
+    except Exception:
+        logger.exception("[pokemon-set-cards] set lookup failed set_id=%s", resolved_set_id)
+        raise PokemonSetCardsError(
+            status_code=500,
+            message="Failed to load set metadata",
+            code="POKEMON_SET_LOOKUP_FAILED",
+        )
+
+    if not set_row:
+        raise PokemonSetCardsError(
+            status_code=404,
+            message="Pokemon set not found",
+            code="POKEMON_SET_NOT_FOUND",
+        )
+
+    cards_started = time.perf_counter()
+    try:
+        cards_result = (
+            public_read_client.table("cards")
+            .select("*")
+            .eq("set_id", resolved_set_id)
+            .execute()
+        )
+        raw_cards = list(cards_result.data or [])
+    except Exception:
+        logger.exception("[pokemon-set-cards] cards query failed set_id=%s", resolved_set_id)
+        raise PokemonSetCardsError(
+            status_code=500,
+            message="Failed to load cards for set",
+            code="POKEMON_SET_CARDS_QUERY_FAILED",
+        )
+    cards_ms = (time.perf_counter() - cards_started) * 1000
+
+    deduped_by_key: Dict[str, Dict[str, Any]] = {}
+    duplicate_count = 0
+    for card in raw_cards:
+        dedupe_key = _build_dedupe_key(resolved_set_id, card)
+        existing = deduped_by_key.get(dedupe_key)
+        if existing is None:
+            deduped_by_key[dedupe_key] = card
+            continue
+
+        duplicate_count += 1
+        if _card_quality_score(card) > _card_quality_score(existing):
+            deduped_by_key[dedupe_key] = card
+
+    cards: List[Dict[str, Any]] = []
+    for card in deduped_by_key.values():
+        cards.append(
+            {
+                "id": _to_optional_str(card.get("id")),
+                "name": _to_optional_str(card.get("name")),
+                "set_id": _to_optional_str(card.get("set_id")) or resolved_set_id,
+                "set_name": _to_optional_str(set_row.get("name")),
+                "card_number": _resolve_card_number(card),
+                "rarity": _to_optional_str(card.get("rarity")),
+                "image_small_url": _resolve_image_small(card),
+                "image_large_url": _resolve_image_large(card),
+                "market_price": _resolve_market_price(card),
+                "tcgplayer_product_id": _to_optional_str(card.get("tcgplayer_product_id")),
+            }
+        )
+
+    cards.sort(key=_sort_key)
+
+    return {
+        "set": {
+            "id": _to_optional_str(set_row.get("id")) or resolved_set_id,
+            "name": _to_optional_str(set_row.get("name")),
+            "slug": _to_optional_str(set_row.get("canonical_key")),
+        },
+        "cards": cards,
+        "meta": {
+            "dedupe": {
+                "strategy": "pokemon_tcg_api_id -> set_id+card_number+normalized_name -> set_id+card_number -> set_id+normalized_name -> cards.id",
+                "input_count": len(raw_cards),
+                "output_count": len(cards),
+                "removed_duplicates": duplicate_count,
+            },
+            "sources": {
+                "cards": "cards",
+            },
+            "timings": {
+                "cards_query_ms": round(cards_ms, 3),
+                "total_backend_ms": round((time.perf_counter() - total_started) * 1000, 3),
+            },
+        },
+    }

--- a/backend/db/services/pokemon_sets_catalog_service.py
+++ b/backend/db/services/pokemon_sets_catalog_service.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import logging
+import re
+import time
+from typing import Any, Dict, List, Optional
+
+from backend.db.clients.supabase_client import public_read_client
+
+logger = logging.getLogger(__name__)
+
+TCG_NAME_CANDIDATES = ("Pokemon", "Pok\u00e9mon")
+
+
+class PokemonSetsCatalogError(Exception):
+    def __init__(self, status_code: int, message: str, code: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
+        self.code = code
+
+
+def _to_optional_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _to_optional_int(value: Any) -> Optional[int]:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed
+
+
+def _slugify(value: str) -> str:
+    lowered = str(value or "").strip().lower()
+    lowered = re.sub(r"\s+", "-", lowered)
+    lowered = re.sub(r"[^\w-]+", "", lowered)
+    lowered = re.sub(r"-{2,}", "-", lowered)
+    return lowered.strip("-")
+
+
+def _resolve_pokemon_tcg_id() -> Optional[str]:
+    for candidate in TCG_NAME_CANDIDATES:
+        try:
+            result = (
+                public_read_client.table("tcgs")
+                .select("id,name")
+                .eq("name", candidate)
+                .limit(1)
+                .execute()
+            )
+            rows = result.data or []
+            if rows:
+                resolved = _to_optional_str(rows[0].get("id"))
+                if resolved:
+                    return resolved
+        except Exception as exc:
+            logger.warning("[pokemon-sets-catalog] tcg lookup failed for candidate=%s error=%s", candidate, exc)
+
+    try:
+        fallback_result = (
+            public_read_client.table("tcgs")
+            .select("id,name")
+            .ilike("name", "pokemon")
+            .limit(1)
+            .execute()
+        )
+        fallback_rows = fallback_result.data or []
+        if fallback_rows:
+            return _to_optional_str(fallback_rows[0].get("id"))
+    except Exception as exc:
+        logger.warning("[pokemon-sets-catalog] tcg fallback lookup failed error=%s", exc)
+
+    return None
+
+
+def _resolve_card_count(set_row: Dict[str, Any]) -> Optional[int]:
+    for key in ("official_card_count", "printed_total", "total_cards", "card_count"):
+        value = _to_optional_int(set_row.get(key))
+        if value is not None and value >= 0:
+            return value
+    return None
+
+
+def get_pokemon_sets_catalog_payload() -> Dict[str, Any]:
+    total_started = time.perf_counter()
+    warnings: List[str] = []
+    sources: Dict[str, str] = {}
+
+    tcg_id_started = time.perf_counter()
+    tcg_id = _resolve_pokemon_tcg_id()
+    tcg_id_ms = (time.perf_counter() - tcg_id_started) * 1000
+
+    if not tcg_id:
+        raise PokemonSetsCatalogError(
+            status_code=404,
+            message="Pokemon TCG was not found",
+            code="POKEMON_TCG_NOT_FOUND",
+        )
+
+    sets_started = time.perf_counter()
+    try:
+        sets_result = (
+            public_read_client.table("sets")
+            .select("*")
+            .eq("tcg_id", tcg_id)
+            .order("release_date", desc=True)
+            .order("name")
+            .execute()
+        )
+        raw_sets = list(sets_result.data or [])
+        sources["sets"] = "OK"
+    except Exception:
+        logger.exception("[pokemon-sets-catalog] sets query failed tcg_id=%s", tcg_id)
+        raise PokemonSetsCatalogError(
+            status_code=500,
+            message="Failed to load Pokemon sets",
+            code="POKEMON_SETS_QUERY_FAILED",
+        )
+    sets_ms = (time.perf_counter() - sets_started) * 1000
+
+    era_lookup: Dict[str, Dict[str, Any]] = {}
+    era_ids = sorted(
+        {
+            str(set_row.get("era_id"))
+            for set_row in raw_sets
+            if set_row.get("era_id") is not None
+        }
+    )
+
+    eras_started = time.perf_counter()
+    if era_ids:
+        try:
+            era_result = (
+                public_read_client.table("eras")
+                .select("id,name")
+                .in_("id", era_ids)
+                .execute()
+            )
+            era_lookup = {
+                str(era_row.get("id")): era_row
+                for era_row in (era_result.data or [])
+                if era_row.get("id") is not None
+            }
+            sources["eras"] = "OK"
+        except Exception as exc:
+            logger.warning("[pokemon-sets-catalog] eras lookup failed error=%s", exc)
+            warnings.append("Failed to load era metadata for one or more sets")
+            sources["eras"] = "FAILED"
+    else:
+        sources["eras"] = "SKIPPED"
+    eras_ms = (time.perf_counter() - eras_started) * 1000
+
+    sets: List[Dict[str, Any]] = []
+    for set_row in raw_sets:
+        set_id = _to_optional_str(set_row.get("id"))
+        if not set_id:
+            continue
+
+        name = _to_optional_str(set_row.get("name")) or set_id
+        canonical_key = _to_optional_str(set_row.get("canonical_key"))
+        pokemon_api_set_id = _to_optional_str(set_row.get("pokemon_api_set_id"))
+        era_id = _to_optional_str(set_row.get("era_id"))
+        era_name = _to_optional_str((era_lookup.get(era_id) or {}).get("name")) if era_id else None
+        resolved_card_count = _resolve_card_count(set_row)
+        official_card_count = _to_optional_int(set_row.get("official_card_count"))
+        printed_total = _to_optional_int(set_row.get("printed_total"))
+        total_cards = _to_optional_int(set_row.get("total_cards"))
+
+        resolved_slug = canonical_key or _slugify(name) or _slugify(set_id)
+
+        sets.append(
+            {
+                "id": set_id,
+                "name": name,
+                "slug": resolved_slug,
+                "canonical_key": canonical_key,
+                "era_id": era_id,
+                "era": era_name,
+                "era_name": era_name,
+                "series": _to_optional_str(set_row.get("series")),
+                "release_date": _to_optional_str(set_row.get("release_date")),
+                "card_count": resolved_card_count,
+                "official_card_count": official_card_count,
+                "printed_total": printed_total,
+                "total_cards": total_cards,
+                "set_code": _to_optional_str(set_row.get("set_code"))
+                or _to_optional_str(set_row.get("abbreviation"))
+                or pokemon_api_set_id,
+                "pokemon_api_set_id": pokemon_api_set_id,
+                "logo_url": _to_optional_str(set_row.get("logo_image_url")),
+                "symbol_url": _to_optional_str(set_row.get("symbol_image_url")),
+                "image_url": _to_optional_str(set_row.get("hero_image_url")),
+                "logo_image_url": _to_optional_str(set_row.get("logo_image_url")),
+                "symbol_image_url": _to_optional_str(set_row.get("symbol_image_url")),
+                "hero_image_url": _to_optional_str(set_row.get("hero_image_url")),
+            }
+        )
+
+    return {
+        "sets": sets,
+        "meta": {
+            "warnings": warnings,
+            "sources": sources,
+            "timings": {
+                "tcg_id_lookup_ms": round(tcg_id_ms, 3),
+                "sets_query_ms": round(sets_ms, 3),
+                "eras_query_ms": round(eras_ms, 3),
+                "total_backend_ms": round((time.perf_counter() - total_started) * 1000, 3),
+            },
+        },
+    }

--- a/backend/jobs/evr_runner.py
+++ b/backend/jobs/evr_runner.py
@@ -6,7 +6,12 @@ import sys
 from copy import deepcopy
 from typing import Any, Dict
 
-from backend.calculations.evr import compute_all_derived_metrics, print_derived_metrics_summary
+from backend.calculations.evr import (
+    compute_all_derived_metrics,
+    compute_hit_value_metrics,
+    compute_simulated_set_value,
+    print_derived_metrics_summary,
+)
 from backend.calculations.evrEtb import calculate_etb_metrics
 from backend.calculations.packCalcsRefractored import calculate_pack_stats
 from backend.constants.tcg.pokemon.megaEvolutionEra.setMap import (
@@ -521,6 +526,18 @@ class EVRRunOrchestrator:
             statistics.median(sim_results.get("values", [0.0])),
         )
         pack_price_value = _safe_pack_price(pack_price)
+        packs_simulated = len(sim_results.get("values", []) or [])
+        hit_value_metrics = compute_hit_value_metrics(
+            rarity_pull_counts=sim_results.get("rarity_pull_counts", {}) or {},
+            rarity_value_totals=sim_results.get("rarity_value_totals", {}) or {},
+            packs_simulated=packs_simulated,
+            config=config,
+        )
+        set_value_metrics = compute_simulated_set_value(
+            calculation_input,
+            config=config,
+            set_id=canonical_key,
+        )
 
         results.update(
             {
@@ -539,6 +556,8 @@ class EVRRunOrchestrator:
             total_pack_ev=pack_metrics.get("total_ev"),
             hit_ev=results.get("hit_ev"),
             hit_cards_count=len(results.get("hit_ev_contributions", {})) if results.get("hit_ev_contributions") else None,
+            hit_value_metrics=hit_value_metrics,
+            set_value_metrics=set_value_metrics,
         )
         print_derived_metrics_summary(derived)
 

--- a/backend/tests/unit/calculations/test_hit_value_metrics.py
+++ b/backend/tests/unit/calculations/test_hit_value_metrics.py
@@ -1,0 +1,117 @@
+from types import MappingProxyType
+
+import pandas as pd
+import pytest
+
+from backend.calculations.evr.hit_value_metrics import (
+    compute_hit_value_metrics,
+    compute_simulated_set_value,
+)
+
+
+class _Config:
+    RARITY_MAPPING = MappingProxyType(
+        {
+            "common": "common",
+            "uncommon": "uncommon",
+            "rare": "rare",
+            "ultra rare": "hits",
+            "illustration rare": "hits",
+            "special illustration rare": "hits",
+            "hyper rare": "hits",
+            "poke ball pattern": "hits",
+            "master ball pattern": "hits",
+        }
+    )
+
+
+def test_compute_hit_value_metrics_excludes_patterns_and_preserves_pack_ev_inputs():
+    metrics = compute_hit_value_metrics(
+        rarity_pull_counts={
+            "common": 20,
+            "ultra rare": 2,
+            "special illustration rare": 1,
+            "poke ball pattern": 5,
+            "master ball pattern": 3,
+        },
+        rarity_value_totals={
+            "common": 2.0,
+            "ultra rare": 30.0,
+            "special illustration rare": 90.0,
+            "poke ball pattern": 500.0,
+            "master ball pattern": 300.0,
+        },
+        packs_simulated=10,
+        config=_Config(),
+    )
+
+    assert metrics["total_value_hit_cards_pulled"] == pytest.approx(120.0)
+    assert metrics["hit_cards_pulled"] == 3
+    assert metrics["average_hit_value"] == pytest.approx(40.0)
+    assert metrics["hit_ev_per_pack"] == pytest.approx(12.0)
+    assert metrics["hit_pull_rate"] == pytest.approx(0.3)
+
+
+def test_compute_hit_value_metrics_returns_null_average_when_zero_hits():
+    metrics = compute_hit_value_metrics(
+        rarity_pull_counts={"common": 20, "poke ball pattern": 2},
+        rarity_value_totals={"common": 2.0, "poke ball pattern": 100.0},
+        packs_simulated=10,
+        config=_Config(),
+    )
+
+    assert metrics["hit_cards_pulled"] == 0
+    assert metrics["average_hit_value"] is None
+    assert metrics["hit_ev_per_pack"] == pytest.approx(0.0)
+    assert metrics["hit_pull_rate"] == pytest.approx(0.0)
+
+
+def test_compute_simulated_set_value_collapses_variants_by_canonical_card_id():
+    df = pd.DataFrame(
+        [
+            {
+                "card_id": "card-1",
+                "Card Name": "Bulbasaur",
+                "Card Number": "001",
+                "Rarity": "common",
+                "Special Type": "",
+                "Price ($)": 1.25,
+            },
+            {
+                "card_id": "card-1",
+                "Card Name": "Bulbasaur",
+                "Card Number": "001",
+                "Rarity": "common",
+                "Special Type": "Poke Ball Pattern",
+                "Price ($)": 10.0,
+            },
+            {
+                "card_id": "card-2",
+                "Card Name": "Ivysaur",
+                "Card Number": "002",
+                "Rarity": "uncommon",
+                "Special Type": "",
+                "Price ($)": 2.75,
+            },
+        ]
+    )
+
+    metrics = compute_simulated_set_value(df, config=_Config(), set_id="test-set")
+
+    assert metrics["simulated_set_value"] == pytest.approx(4.0)
+    assert metrics["simulated_set_value_card_count"] == 2
+
+
+def test_compute_simulated_set_value_fallback_identity_counts_distinct_numbers():
+    df = pd.DataFrame(
+        [
+            {"Card Name": "Pikachu", "Card Number": "025", "Rarity": "rare", "Price ($)": 3.0},
+            {"Card Name": "Pikachu", "Card Number": "026", "Rarity": "rare", "Price ($)": 4.0},
+            {"Card Name": "Missing Price", "Card Number": "027", "Rarity": "rare", "Price ($)": None},
+        ]
+    )
+
+    metrics = compute_simulated_set_value(df, config=_Config(), set_id="test-set")
+
+    assert metrics["simulated_set_value"] == pytest.approx(7.0)
+    assert metrics["simulated_set_value_card_count"] == 2

--- a/backend/tests/unit/calculations/test_rarity_classification.py
+++ b/backend/tests/unit/calculations/test_rarity_classification.py
@@ -15,6 +15,8 @@ from backend.calculations.utils.rarity_classification import (
     is_hit_rarity,
     get_rarity_group,
     filter_card_ev_by_hits,
+    is_hit_card,
+    is_hit_row,
 )
 from backend.calculations.utils.special_type_normalization import (
     derive_classification_key,
@@ -319,15 +321,15 @@ class TestFilterCardEvByHits:
         })
         contribs = {'Poke Ball Pattern': 1.0}
 
-        # In SV, poke ball pattern is a hit
+        # In SV, poke ball pattern maps as a simulation hit but is excluded from hit-only metrics.
         hit_sv, non_hit_sv = filter_card_ev_by_hits(contribs, df, MockScarletVioletConfig())
-        assert 'Poke Ball Pattern' in hit_sv
+        assert 'Poke Ball Pattern' in non_hit_sv
 
         # In a config without it, it's not found → assumed non-hit
         hit_none, non_hit_none = filter_card_ev_by_hits(contribs, df, NoSpecialsConfig())
         assert 'Poke Ball Pattern' in non_hit_none
 
-    def test_excluded_pokeball_pattern_is_omitted_from_hit_pool_only(self):
+    def test_pattern_rarities_are_omitted_from_hit_pool_by_default(self):
         df = pd.DataFrame(
             {
                 "Card Name": ["Poke Ball Pattern A", "Master Ball Pattern A", "Ultra A"],
@@ -340,10 +342,42 @@ class TestFilterCardEvByHits:
         hit, non_hit = filter_card_ev_by_hits(
             contribs,
             df,
-            MockScarletVioletExcludedPokeBallConfig(),
+            MockScarletVioletConfig(),
         )
 
         assert "001" not in hit
         assert "001" in non_hit
-        assert "002" in hit
+        assert "002" not in hit
+        assert "002" in non_hit
         assert "003" in hit
+
+    @pytest.mark.parametrize(
+        "rarity",
+        [
+            "Poke Ball Pattern",
+            "Pok\u00e9 Ball Pattern",
+            "Pokeball Pattern",
+            "Master Ball Pattern",
+            "Masterball Pattern",
+        ],
+    )
+    def test_pattern_equivalents_are_not_hit_cards_for_hit_only_metrics(self, rarity):
+        assert not is_hit_card({"Rarity": rarity}, MockScarletVioletConfig())
+
+    def test_pattern_classification_key_is_excluded_even_with_base_rarity(self):
+        assert not is_hit_card(
+            {"Rarity": "common", "classification_key": "pokeball_pattern"},
+            MockScarletVioletConfig(),
+        )
+
+    def test_hit_row_uses_hit_only_exclusions(self):
+        row = pd.Series({"Rarity": "common", "classification_key": "master_ball_pattern"})
+
+        assert not is_hit_row(row, MockScarletVioletConfig())
+
+    @pytest.mark.parametrize(
+        "rarity",
+        ["special illustration rare", "illustration rare", "ultra rare", "hyper rare"],
+    )
+    def test_modern_hit_rarities_are_hit_cards(self, rarity):
+        assert is_hit_card({"Rarity": rarity}, MockScarletVioletConfig())

--- a/backend/tests/unit/db/repositories/test_calculation_runs_repository.py
+++ b/backend/tests/unit/db/repositories/test_calculation_runs_repository.py
@@ -109,6 +109,12 @@ def test_create_simulation_derived_metrics_persists_placeholder_with_null_scores
     inserted_payload = mock_insert_required_payload.call_args.args[1]
     assert inserted_payload == {
         "calculation_run_id": "run-1",
+        "simulated_set_value": None,
+        "simulated_set_value_card_count": None,
+        "average_hit_value": None,
+        "hit_ev_per_pack": None,
+        "hit_pull_rate": None,
+        "hit_cards_pulled": None,
         "hit_ev": 6.16,
         "non_hit_ev": 1.02,
         "hit_ev_share": 0.858,
@@ -150,6 +156,12 @@ def test_create_simulation_derived_metrics_allows_missing_composite_fields(mock_
     inserted_payload = mock_insert_required_payload.call_args.args[1]
     assert inserted_payload == {
         "calculation_run_id": "run-1",
+        "simulated_set_value": None,
+        "simulated_set_value_card_count": None,
+        "average_hit_value": None,
+        "hit_ev_per_pack": None,
+        "hit_pull_rate": None,
+        "hit_cards_pulled": None,
         "hit_ev": None,
         "non_hit_ev": None,
         "hit_ev_share": None,
@@ -179,6 +191,31 @@ def test_create_simulation_derived_metrics_allows_missing_composite_fields(mock_
         "experience_tier": None,
         "derived_metric_version": None,
     }
+
+
+@patch("backend.db.repositories.calculation_runs_repository._insert_required_payload")
+def test_create_simulation_derived_metrics_persists_hit_and_set_value_fields(mock_insert_required_payload):
+    mock_insert_required_payload.return_value = {"id": "derived-1"}
+
+    create_simulation_derived_metrics(
+        "run-1",
+        {
+            "simulated_set_value": "123.45",
+            "simulated_set_value_card_count": "2",
+            "average_hit_value": "40.0",
+            "hit_ev_per_pack": "12.0",
+            "hit_pull_rate": "0.3",
+            "hit_cards_pulled": "3",
+        },
+    )
+
+    inserted_payload = mock_insert_required_payload.call_args.args[1]
+    assert inserted_payload["simulated_set_value"] == pytest.approx(123.45)
+    assert inserted_payload["simulated_set_value_card_count"] == 2
+    assert inserted_payload["average_hit_value"] == pytest.approx(40.0)
+    assert inserted_payload["hit_ev_per_pack"] == pytest.approx(12.0)
+    assert inserted_payload["hit_pull_rate"] == pytest.approx(0.3)
+    assert inserted_payload["hit_cards_pulled"] == 3
 
 
 @patch("backend.db.repositories.calculation_runs_repository._insert_required_payload")
@@ -242,6 +279,12 @@ def test_create_simulation_derived_metrics_persists_real_scores_when_present(moc
     inserted_payload = mock_insert_required_payload.call_args.args[1]
     assert inserted_payload == {
         "calculation_run_id": "run-1",
+        "simulated_set_value": None,
+        "simulated_set_value_card_count": None,
+        "average_hit_value": None,
+        "hit_ev_per_pack": None,
+        "hit_pull_rate": None,
+        "hit_cards_pulled": None,
         "hit_ev": 6.16,
         "non_hit_ev": 1.02,
         "hit_ev_share": 0.858,
@@ -304,6 +347,12 @@ def test_create_simulation_derived_metrics_persists_only_composite_stage1_fields
     inserted_payload = mock_insert_required_payload.call_args.args[1]
     assert inserted_payload == {
         "calculation_run_id": "run-1",
+        "simulated_set_value": None,
+        "simulated_set_value_card_count": None,
+        "average_hit_value": None,
+        "hit_ev_per_pack": None,
+        "hit_pull_rate": None,
+        "hit_cards_pulled": None,
         "hit_ev": None,
         "non_hit_ev": None,
         "hit_ev_share": None,
@@ -446,6 +495,18 @@ def test_get_latest_run_snapshot_for_target_returns_none_when_no_runs_exist(_moc
 def test_derived_metric_fields_include_pack_score_v2_concentration_fields():
     assert "hhi_ev_concentration" in DERIVED_METRIC_FIELDS
     assert "effective_chase_count" in DERIVED_METRIC_FIELDS
+
+
+def test_derived_metric_fields_include_hit_and_set_value_fields():
+    for field in [
+        "simulated_set_value",
+        "simulated_set_value_card_count",
+        "average_hit_value",
+        "hit_ev_per_pack",
+        "hit_pull_rate",
+        "hit_cards_pulled",
+    ]:
+        assert field in DERIVED_METRIC_FIELDS
 
 
 def test_derived_metric_fields_include_stage1_composites_but_not_internal_components():

--- a/backend/tests/unit/db/services/test_calculation_run_persistence_service.py
+++ b/backend/tests/unit/db/services/test_calculation_run_persistence_service.py
@@ -110,6 +110,12 @@ def test_persist_simulation_derived_metrics_maps_required_fields_from_runtime(mo
     mock_create_simulation_derived_metrics.assert_called_once_with(
         "run-1",
         {
+            "simulated_set_value": None,
+            "simulated_set_value_card_count": None,
+            "average_hit_value": None,
+            "hit_ev_per_pack": None,
+            "hit_pull_rate": None,
+            "hit_cards_pulled": None,
             "hit_ev": 6.16,
             "non_hit_ev": 1.02,
             "hit_ev_share": 0.858,
@@ -189,6 +195,60 @@ def test_persist_simulation_derived_metrics_prefers_primary_chase_aliases_when_b
 
 
 @patch("backend.db.services.calculation_run_persistence_service.create_simulation_derived_metrics")
+def test_persist_simulation_derived_metrics_maps_hit_and_set_value_metrics(
+    mock_create_simulation_derived_metrics,
+):
+    mock_create_simulation_derived_metrics.return_value = [{"id": "derived-1"}]
+
+    persist_simulation_derived_metrics(
+        run_id="run-1",
+        derived={
+            "ev_composition_metrics": {
+                "total_pack_ev": 7.18,
+                "hit_ev": 6.16,
+                "non_hit_ev": 1.02,
+                "hit_ev_share_of_pack_ev": 0.858,
+                "hit_cards_count": 208,
+            },
+            "chase_dependency_metrics": {
+                "n_cards": 600,
+                "total_ev": 7.18,
+                "top1_ev_share": 0.22,
+                "top3_ev_share": 0.47,
+                "top5_ev_share": 0.63,
+            },
+            "hit_value_metrics": {
+                "average_hit_value": 40.0,
+                "hit_ev_per_pack": 12.0,
+                "hit_pull_rate": 0.3,
+                "hit_cards_pulled": 3,
+            },
+            "set_value_metrics": {
+                "simulated_set_value": 123.45,
+                "simulated_set_value_card_count": 2,
+            },
+            "pack_score": {
+                "pack_score": 72.4,
+                "profit_score": 71.0,
+                "safety_score": 37.0,
+                "stability_score": 65.0,
+                "score_version": "pack_score_v1_singleton_placeholder",
+                "normalization_mode": "singleton_placeholder",
+                "pack_score_is_placeholder": True,
+            },
+        },
+    )
+
+    persisted_payload = mock_create_simulation_derived_metrics.call_args.args[1]
+    assert persisted_payload["simulated_set_value"] == pytest.approx(123.45)
+    assert persisted_payload["simulated_set_value_card_count"] == 2
+    assert persisted_payload["average_hit_value"] == pytest.approx(40.0)
+    assert persisted_payload["hit_ev_per_pack"] == pytest.approx(12.0)
+    assert persisted_payload["hit_pull_rate"] == pytest.approx(0.3)
+    assert persisted_payload["hit_cards_pulled"] == 3
+
+
+@patch("backend.db.services.calculation_run_persistence_service.create_simulation_derived_metrics")
 def test_persist_simulation_derived_metrics_accepts_legacy_chase_metric_names(mock_create_simulation_derived_metrics):
     mock_create_simulation_derived_metrics.return_value = [{"id": "derived-1"}]
 
@@ -222,6 +282,12 @@ def test_persist_simulation_derived_metrics_accepts_legacy_chase_metric_names(mo
     mock_create_simulation_derived_metrics.assert_called_once_with(
         "run-1",
         {
+            "simulated_set_value": None,
+            "simulated_set_value_card_count": None,
+            "average_hit_value": None,
+            "hit_ev_per_pack": None,
+            "hit_pull_rate": None,
+            "hit_cards_pulled": None,
             "hit_ev": 6.16,
             "non_hit_ev": 1.02,
             "hit_ev_share": 0.858,
@@ -340,6 +406,12 @@ def test_persist_simulation_derived_metrics_coerces_empty_shares_to_zero(mock_cr
     mock_create_simulation_derived_metrics.assert_called_once_with(
         "run-1",
         {
+            "simulated_set_value": None,
+            "simulated_set_value_card_count": None,
+            "average_hit_value": None,
+            "hit_ev_per_pack": None,
+            "hit_pull_rate": None,
+            "hit_cards_pulled": None,
             "hit_ev": 0.0,
             "non_hit_ev": 0.0,
             "hit_ev_share": 0.0,

--- a/backend/tests/unit/db/services/test_explore_page_service.py
+++ b/backend/tests/unit/db/services/test_explore_page_service.py
@@ -88,6 +88,12 @@ def _build_success_handlers(run_id="run-1"):
                 "std_dev": 3.20,
                 "roi_percent": 11.2,
                 "prob_profit": 0.54,
+                "simulated_set_value": 123.45,
+                "simulated_set_value_card_count": 2,
+                "average_hit_value": 40.0,
+                "hit_ev_per_pack": 12.0,
+                "hit_pull_rate": 0.3,
+                "hit_cards_pulled": 3,
                 "pack_score": 0.72,
                 "profit_score": 0.68,
                 "safety_score": 0.81,
@@ -136,6 +142,12 @@ def test_rip_latest_summary_is_preferred_for_set_targets(monkeypatch):
             "median_value": 5.10,
             "roi_percent": 11.2,
             "prob_profit": 0.54,
+            "simulated_set_value": 123.45,
+            "simulated_set_value_card_count": 2,
+            "average_hit_value": 40.0,
+            "hit_ev_per_pack": 12.0,
+            "hit_pull_rate": 0.3,
+            "hit_cards_pulled": 3,
             "p95_value_to_cost_ratio": 1.9,
             "p99_value_to_cost_ratio": 2.5,
             "mean_value_to_cost_ratio": 1.11,
@@ -163,6 +175,12 @@ def test_rip_latest_summary_is_preferred_for_set_targets(monkeypatch):
 
     assert payload["summary"]["relative_pack_score"] == 81.4
     assert payload["summary"]["pack_rank"] == 3
+    assert payload["summary"]["simulated_set_value"] == 123.45
+    assert payload["summary"]["simulated_set_value_card_count"] == 2
+    assert payload["summary"]["average_hit_value"] == 40.0
+    assert payload["summary"]["hit_ev_per_pack"] == 12.0
+    assert payload["summary"]["hit_pull_rate"] == 0.3
+    assert payload["summary"]["hit_cards_pulled"] == 3
     assert payload["meta"]["sources"]["summary_source"] == "explore_rip_statistics_latest"
     assert payload["meta"]["sources"]["latest_target_source"] == "explore_rip_statistics_latest"
 

--- a/backend/tests/unit/simulations/test_derived_metrics.py
+++ b/backend/tests/unit/simulations/test_derived_metrics.py
@@ -1129,6 +1129,29 @@ class TestComputeAllDerivedMetrics:
         )
         assert result["ev_composition_metrics"]["hit_cards_count"] == 208
 
+    def test_hit_and_set_value_metrics_present_when_supplied(self):
+        result = compute_all_derived_metrics(
+            TOY_VALUES,
+            PACK_COST,
+            hit_value_metrics={
+                "average_hit_value": 40.0,
+                "hit_ev_per_pack": 12.0,
+                "hit_pull_rate": 0.3,
+                "hit_cards_pulled": 3,
+            },
+            set_value_metrics={
+                "simulated_set_value": 123.45,
+                "simulated_set_value_card_count": 2,
+            },
+        )
+
+        assert result["hit_value_metrics"]["average_hit_value"] == pytest.approx(40.0)
+        assert result["hit_value_metrics"]["hit_ev_per_pack"] == pytest.approx(12.0)
+        assert result["hit_value_metrics"]["hit_pull_rate"] == pytest.approx(0.3)
+        assert result["hit_value_metrics"]["hit_cards_pulled"] == 3
+        assert result["set_value_metrics"]["simulated_set_value"] == pytest.approx(123.45)
+        assert result["set_value_metrics"]["simulated_set_value_card_count"] == 2
+
 
 # ---------------------------------------------------------------------------
 # 11. PackSimulationSummary dataclass and builder

--- a/frontend/app/Explore/rip-statistics/page.js
+++ b/frontend/app/Explore/rip-statistics/page.js
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import RipStatisticsPageClient from "@/components/explore/RipStatisticsPageClient";
 import { getExplorePagePayload } from "@/lib/explore/explorePageServer";
 import { getRipStatisticsTargets } from "@/lib/explore/ripStatisticsServer";
+import { buildTargetHrefById, buildTcgSetHrefFromTarget } from "@/lib/explore/ripStatisticsRouting";
 
 function readParamValue(searchParams, key) {
   const raw = searchParams?.[key];
@@ -18,13 +19,23 @@ export default async function RipStatisticsPage({ searchParams }) {
   const requestedTargetId = readParamValue(resolvedSearchParams, "target_id");
 
   const targetsPayload = await getRipStatisticsTargets({ limit: 150 });
+  const targets = Array.isArray(targetsPayload?.targets) ? targetsPayload.targets : [];
   const defaultTarget = targetsPayload?.default_target || null;
+  const targetHrefById = buildTargetHrefById(targets);
 
   if (!requestedTargetId) {
     if (defaultTarget?.target_type && defaultTarget?.target_id) {
-      redirect(
-        `/Explore/rip-statistics?target_type=${encodeURIComponent(defaultTarget.target_type)}&target_id=${encodeURIComponent(defaultTarget.target_id)}`
-      );
+      if (String(defaultTarget.target_type).toLowerCase() === "set") {
+        redirect(buildTcgSetHrefFromTarget(defaultTarget));
+      }
+      redirect(`/Explore/rip-statistics?target_type=${encodeURIComponent(defaultTarget.target_type)}&target_id=${encodeURIComponent(defaultTarget.target_id)}`);
+    }
+  }
+
+  if (requestedTargetType === "set" && requestedTargetId) {
+    const matchingSetTarget = targets.find((target) => String(target?.target_id || "") === requestedTargetId);
+    if (matchingSetTarget) {
+      redirect(buildTcgSetHrefFromTarget(matchingSetTarget));
     }
   }
 
@@ -42,7 +53,7 @@ export default async function RipStatisticsPage({ searchParams }) {
   }
 
   const selectedTarget =
-    targetsPayload.targets.find(
+    targets.find(
       (target) =>
         String(target?.target_type || "") === requestedTargetType &&
         String(target?.target_id || "") === requestedTargetId
@@ -56,6 +67,7 @@ export default async function RipStatisticsPage({ searchParams }) {
       requestedTargetId={requestedTargetId}
       explorePayload={explorePayload}
       pageError={pageError}
+      targetHrefById={targetHrefById}
     />
   );
 }

--- a/frontend/app/TCGs/Pokemon/Sets/[setSlug]/loading.js
+++ b/frontend/app/TCGs/Pokemon/Sets/[setSlug]/loading.js
@@ -1,0 +1,16 @@
+import InDexLogoLoader from "@/components/brand/InDexLogoLoader";
+
+export default function TcgSetLoading() {
+  return (
+    <InDexLogoLoader
+      fullScreen
+      label="Loading Rip Statistics"
+      shouldDelay={true}
+      isLoading={true}
+      delayConfig={{
+        showDelayMs: 200,
+        minVisibleMs: 450,
+      }}
+    />
+  );
+}

--- a/frontend/app/TCGs/Pokemon/Sets/[setSlug]/page.js
+++ b/frontend/app/TCGs/Pokemon/Sets/[setSlug]/page.js
@@ -1,0 +1,57 @@
+import RipStatisticsPageClient from "@/components/explore/RipStatisticsPageClient";
+import { getExplorePagePayload } from "@/lib/explore/explorePageServer";
+import { getRipStatisticsTargets } from "@/lib/explore/ripStatisticsServer";
+import {
+  buildTargetHrefById,
+  buildTcgSetHrefFromTarget,
+  findTargetBySetSlug,
+} from "@/lib/explore/ripStatisticsRouting";
+import { redirect } from "next/navigation";
+
+export default async function TcgSetRipStatisticsPage({ params }) {
+  const resolvedParams = (await params) || {};
+  const requestedSetSlug = String(resolvedParams?.setSlug || "").trim().toLowerCase();
+
+  const targetsPayload = await getRipStatisticsTargets({ limit: 150 });
+  const targets = Array.isArray(targetsPayload?.targets) ? targetsPayload.targets : [];
+  const defaultTarget = targetsPayload?.default_target || null;
+  const targetHrefById = buildTargetHrefById(targets);
+
+  if (!requestedSetSlug && defaultTarget?.target_type === "set") {
+    redirect(buildTcgSetHrefFromTarget(defaultTarget));
+  }
+
+  const selectedTarget = findTargetBySetSlug(targets, requestedSetSlug);
+  const requestedTargetType = selectedTarget?.target_type || "set";
+  const requestedTargetId = selectedTarget?.target_id || "";
+
+  let explorePayload = null;
+  let pageError = null;
+
+  if (selectedTarget?.target_id) {
+    try {
+      explorePayload = await getExplorePagePayload(requestedTargetType, requestedTargetId);
+      if (!explorePayload) {
+        pageError = "No persisted RIP Statistics payload is available for this set.";
+      }
+    } catch (error) {
+      pageError = error?.message || "Failed to load RIP Statistics.";
+    }
+  } else {
+    pageError = "Set not found for this URL.";
+  }
+
+  return (
+    <RipStatisticsPageClient
+      targetsPayload={targetsPayload}
+      selectedTarget={selectedTarget}
+      requestedTargetType={requestedTargetType}
+      requestedTargetId={requestedTargetId}
+      explorePayload={explorePayload}
+      pageError={pageError}
+      profileBaseHref="/TCGs/Pokemon/Sets"
+      targetHrefById={targetHrefById}
+      setDetailMode
+    />
+  );
+}

--- a/frontend/app/TCGs/Pokemon/Sets/loading.js
+++ b/frontend/app/TCGs/Pokemon/Sets/loading.js
@@ -1,0 +1,24 @@
+import SecondaryNav from "@/components/SecondaryNav";
+
+export default function LoadingPokemonSetsPage() {
+  return (
+    <div className="min-h-screen bg-[var(--surface-page)]">
+      <SecondaryNav basePath="/TCGs/Pokemon" />
+      <main className="w-full px-2 md:px-6 lg:px-10 py-8">
+        <div className="max-w-6xl mx-auto">
+          <div className="dashboard-container">
+            <h1 className="text-3xl md:text-4xl font-bold text-[var(--text-primary)] mb-3">
+              Pokémon TCG Sets
+            </h1>
+            <p className="text-base md:text-lg text-[var(--text-secondary)] mb-8">
+              Browse Pokémon sets by era, newest to oldest.
+            </p>
+            <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-panel)] p-6 text-[var(--text-secondary)]">
+              Loading Pokémon sets...
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/app/TCGs/Pokemon/Sets/page.js
+++ b/frontend/app/TCGs/Pokemon/Sets/page.js
@@ -1,28 +1,275 @@
-'use client';
+import Link from "next/link";
 import SecondaryNav from "@/components/SecondaryNav";
+import { toSetSlug } from "@/utils/slugify";
+import { getPokemonSets } from "@/lib/pokemon/pokemonSetsServer";
 
-export default function SetsPage() {
+function toTimestamp(value) {
+  if (!value) {
+    return null;
+  }
+  const parsed = Date.parse(String(value));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function toDisplayDate(value) {
+  const text = String(value || "").trim();
+  if (!text) {
+    return null;
+  }
+  const directDateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(text);
+  if (directDateMatch) {
+    return `${directDateMatch[1]}/${directDateMatch[2]}/${directDateMatch[3]}`;
+  }
+  const timestamp = toTimestamp(text);
+  if (timestamp === null) {
+    return null;
+  }
+  const parsedDate = new Date(timestamp);
+  const year = parsedDate.getUTCFullYear();
+  const month = String(parsedDate.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(parsedDate.getUTCDate()).padStart(2, "0");
+  return `${year}/${month}/${day}`;
+}
+
+function getCardCount(setSummary) {
+  const parsed = Number(setSummary?.cardCount ?? null);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return null;
+  }
+  return Math.round(parsed);
+}
+
+function getSetImageUrl(setSummary) {
+  return setSummary?.logoUrl || setSummary?.symbolUrl || setSummary?.imageUrl || null;
+}
+
+function getSetInitials(name) {
+  const words = String(name || "")
+    .split(/\s+/)
+    .map((word) => word.trim())
+    .filter(Boolean)
+    .slice(0, 2);
+
+  if (words.length === 0) {
+    return "PK";
+  }
+
+  return words.map((word) => word[0]).join("").toUpperCase();
+}
+
+function groupSetsByEra(sets) {
+  const eraMap = new Map();
+
+  (Array.isArray(sets) ? sets : []).forEach((setSummary, index) => {
+    const eraName = String(setSummary?.era || setSummary?.series || "Other").trim() || "Other";
+    const currentGroup = eraMap.get(eraName) || {
+      eraName,
+      sets: [],
+      earliestTimestamp: null,
+      latestTimestamp: null,
+      firstSeenIndex: index,
+    };
+
+    const releaseTimestamp = toTimestamp(setSummary?.releaseDate ?? null);
+
+    if (releaseTimestamp !== null) {
+      currentGroup.latestTimestamp =
+        currentGroup.latestTimestamp === null
+          ? releaseTimestamp
+          : Math.max(currentGroup.latestTimestamp, releaseTimestamp);
+      currentGroup.earliestTimestamp =
+        currentGroup.earliestTimestamp === null
+          ? releaseTimestamp
+          : Math.min(currentGroup.earliestTimestamp, releaseTimestamp);
+    }
+
+    currentGroup.sets.push(setSummary);
+    eraMap.set(eraName, currentGroup);
+  });
+
+  return Array.from(eraMap.values())
+    .map((group) => ({
+      ...group,
+      sets: group.sets
+        .map((setSummary, index) => ({
+          ...setSummary,
+          __releaseTimestamp: toTimestamp(setSummary?.releaseDate ?? null),
+          __fallbackIndex: index,
+        }))
+        .sort((a, b) => {
+          if (a.__releaseTimestamp !== null && b.__releaseTimestamp !== null) {
+            return b.__releaseTimestamp - a.__releaseTimestamp;
+          }
+          if (a.__releaseTimestamp !== null) {
+            return -1;
+          }
+          if (b.__releaseTimestamp !== null) {
+            return 1;
+          }
+          return a.__fallbackIndex - b.__fallbackIndex;
+        }),
+    }))
+    .sort((a, b) => {
+      if (a.latestTimestamp !== null && b.latestTimestamp !== null) {
+        return b.latestTimestamp - a.latestTimestamp;
+      }
+      if (a.latestTimestamp !== null) {
+        return -1;
+      }
+      if (b.latestTimestamp !== null) {
+        return 1;
+      }
+      return a.firstSeenIndex - b.firstSeenIndex;
+    });
+}
+
+function formatYearRange(earliestTimestamp, latestTimestamp) {
+  if (earliestTimestamp === null || latestTimestamp === null) {
+    return null;
+  }
+
+  const earliestYear = new Date(earliestTimestamp).getUTCFullYear();
+  const latestYear = new Date(latestTimestamp).getUTCFullYear();
+
+  if (!Number.isFinite(earliestYear) || !Number.isFinite(latestYear)) {
+    return null;
+  }
+
+  if (earliestYear === latestYear) {
+    return String(latestYear);
+  }
+
+  return `${earliestYear} - ${latestYear}`;
+}
+
+export default async function SetsPage() {
+  let sets = [];
+  let loadError = null;
+
+  try {
+    const payload = await getPokemonSets();
+    const summaries = Array.isArray(payload?.sets) ? payload.sets : [];
+    sets = summaries.filter((setSummary) => setSummary?.id && setSummary?.name);
+  } catch (error) {
+    loadError = error?.message || "Failed to load sets";
+  }
+
+  const groupedEras = groupSetsByEra(sets);
+
   return (
     <div className="min-h-screen bg-[var(--surface-page)]">
       <SecondaryNav basePath="/TCGs/Pokemon" />
       <main className="w-full px-2 md:px-6 lg:px-10 py-8">
         <div className="max-w-6xl mx-auto">
           <div className="dashboard-container">
-          <h1 className="text-3xl md:text-4xl font-bold text-[var(--text-primary)] mb-4">
-            Pokémon TCG Sets
-          </h1>
-          <p className="text-lg text-[var(--text-secondary)] mb-8">
-            Browse all available Pokémon Trading Card Game sets.
-          </p>
+            <h1 className="text-3xl md:text-4xl font-bold text-[var(--text-primary)] mb-3">
+              Pokémon TCG Sets
+            </h1>
+            <p className="text-base md:text-lg text-[var(--text-secondary)] mb-8">
+              Browse Pokémon sets by era, newest to oldest.
+            </p>
 
-          <div className="bg-[var(--surface-panel)] rounded-lg border border-[var(--border-subtle)] p-8">
-            <div className="text-center text-[var(--text-secondary)]">
-              <p className="mb-4">Sets database coming soon...</p>
-              <p className="text-sm">This page will display comprehensive information about all Pokémon TCG sets.</p>
-            </div>
+            {loadError ? (
+              <div className="rounded-xl border border-[rgba(239,68,68,0.35)] bg-[rgba(239,68,68,0.08)] p-6 text-center text-[var(--text-primary)]">
+                Unable to load Pokémon sets.
+              </div>
+            ) : null}
+
+            {!loadError && groupedEras.length === 0 ? (
+              <div className="bg-[var(--surface-panel)] rounded-xl border border-[var(--border-subtle)] p-8 text-center text-[var(--text-secondary)]">
+                No Pokémon sets available yet.
+              </div>
+            ) : !loadError ? (
+              <div className="space-y-8">
+                {groupedEras.map((eraGroup) => {
+                  const yearRange = formatYearRange(eraGroup.earliestTimestamp, eraGroup.latestTimestamp);
+                  return (
+                    <section
+                      key={eraGroup.eraName}
+                      className="rounded-2xl border border-[var(--border-subtle)] bg-[linear-gradient(180deg,rgba(16,27,45,0.95)_0%,rgba(9,16,27,0.95)_100%)] p-4 md:p-5"
+                    >
+                      <header className="mb-4">
+                        <div className="mb-3 h-[2px] w-16 rounded-full bg-[var(--accent)]/80" aria-hidden="true" />
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                          <h2 className="text-xl md:text-2xl font-semibold text-[var(--text-primary)]">{eraGroup.eraName}</h2>
+                          <div className="flex items-center gap-2">
+                            <span className="inline-flex items-center rounded-full border border-[var(--border-subtle)] bg-[var(--surface-page)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.06em] text-[var(--text-secondary)]">
+                              {eraGroup.sets.length} {eraGroup.sets.length === 1 ? "Set" : "Sets"}
+                            </span>
+                            {yearRange ? (
+                              <span className="inline-flex items-center rounded-full border border-[var(--border-subtle)] bg-[var(--surface-page)] px-3 py-1 text-xs font-semibold text-[var(--text-secondary)]">
+                                {yearRange}
+                              </span>
+                            ) : null}
+                          </div>
+                        </div>
+                      </header>
+
+                      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 md:gap-5">
+                        {eraGroup.sets.map((setSummary) => {
+                          const setName = String(setSummary?.name || setSummary?.id || "Unknown Set");
+                          const cardCount = getCardCount(setSummary);
+                          const releaseDateText = toDisplayDate(setSummary?.releaseDate ?? null);
+                          const setImageUrl = getSetImageUrl(setSummary);
+                          const slug = toSetSlug(setName, setSummary?.slug || setSummary?.id);
+                          const setHref = slug ? `/TCGs/Pokemon/Sets/${encodeURIComponent(slug)}` : "/TCGs/Pokemon/Sets";
+
+                          return (
+                            <Link
+                              key={String(setSummary?.id || setName)}
+                              href={setHref}
+                              className="group relative overflow-hidden rounded-2xl border border-[var(--border-subtle)] bg-[linear-gradient(180deg,rgba(19,29,52,0.94)_0%,rgba(16,27,45,0.95)_58%,rgba(9,16,27,0.96)_100%)] p-4 md:p-5 transition-colors duration-200 hover:border-[var(--accent)]/55"
+                            >
+                              {setImageUrl ? (
+                                <img
+                                  src={setImageUrl}
+                                  alt=""
+                                  aria-hidden="true"
+                                  className="pointer-events-none absolute -right-[28%] -top-[24%] h-72 w-72 max-w-none opacity-[0.08] object-contain"
+                                  loading="lazy"
+                                  decoding="async"
+                                />
+                              ) : null}
+
+                              <div className="relative z-10 space-y-4">
+                                <div className="flex h-20 w-full items-center justify-center rounded-xl border border-[var(--border-subtle)] bg-[rgba(9,16,27,0.72)]">
+                                  {setImageUrl ? (
+                                    <img
+                                      src={setImageUrl}
+                                      alt={`${setName} logo`}
+                                      className="h-[78%] w-[78%] object-contain"
+                                      loading="lazy"
+                                      decoding="async"
+                                    />
+                                  ) : (
+                                    <span className="text-sm font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)]">
+                                      {getSetInitials(setName)}
+                                    </span>
+                                  )}
+                                </div>
+
+                                <div>
+                                  <h3 className="text-base md:text-lg font-semibold text-[var(--text-primary)] leading-snug">
+                                    {setName}
+                                  </h3>
+
+                                  <div className="mt-2 space-y-1 text-sm text-[var(--text-secondary)]">
+                                    {releaseDateText ? <p>Released: {releaseDateText}</p> : null}
+                                    {cardCount !== null ? <p>{cardCount} cards</p> : null}
+                                  </div>
+                                </div>
+                              </div>
+                            </Link>
+                          );
+                        })}
+                      </div>
+                    </section>
+                  );
+                })}
+              </div>
+            ) : null}
           </div>
-            </div>
-          </div>
+        </div>
       </main>
     </div>
   );

--- a/frontend/app/api/tcgs/pokemon/sets/[setId]/cards/route.js
+++ b/frontend/app/api/tcgs/pokemon/sets/[setId]/cards/route.js
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { getBackendApiBaseUrl } from "@/lib/runtimeUrls";
+
+function getBackendBaseUrl() {
+  return getBackendApiBaseUrl();
+}
+
+export async function GET(request, { params }) {
+  const resolvedParams = (await params) || {};
+  const setId = String(resolvedParams?.setId || "").trim();
+
+  if (!setId) {
+    return NextResponse.json(
+      { message: "setId is required", code: "SET_ID_REQUIRED" },
+      { status: 400 }
+    );
+  }
+
+  const backendUrl = new URL(
+    `${getBackendBaseUrl()}/tcgs/pokemon/sets/${encodeURIComponent(setId)}/cards`
+  );
+
+  const proxyResponse = await fetch(backendUrl.toString(), {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+    },
+    cache: "no-store",
+  });
+
+  const payload = await proxyResponse.text();
+  const contentType = proxyResponse.headers.get("content-type") || "application/json";
+
+  return new NextResponse(payload, {
+    status: proxyResponse.status,
+    headers: {
+      "content-type": contentType,
+    },
+  });
+}

--- a/frontend/components/SecondaryNav.js
+++ b/frontend/components/SecondaryNav.js
@@ -8,7 +8,6 @@ export default function SecondaryNav({ basePath = "/TCGs/Pokemon" }) {
   const navItems = [
     { label: "Overview", path: basePath },
     { label: "Sets", path: `${basePath}/Sets` },
-    { label: "Analytics", path: `${basePath}/Analytics` },
   ];
 
   const isActive = (path) => {

--- a/frontend/components/explore/ExploreTableClient.jsx
+++ b/frontend/components/explore/ExploreTableClient.jsx
@@ -18,6 +18,7 @@ import {
   getTierField,
 } from "@/constants/exploreRankingConfig";
 import { getDangerValueStyle } from "@/lib/explore/interpretationTone";
+import { buildTcgSetHrefFromTarget } from "@/lib/explore/ripStatisticsRouting";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
   style: "currency",
@@ -68,10 +69,7 @@ function estimateAverageLoss(target) {
 }
 
 function buildRipLink(target) {
-  if (!target?.target_type || !target?.target_id) {
-    return "/Explore/rip-statistics";
-  }
-  return `/Explore/rip-statistics?target_type=${encodeURIComponent(target.target_type)}&target_id=${encodeURIComponent(target.target_id)}`;
+  return buildTcgSetHrefFromTarget(target);
 }
 
 function getLeaderboardRecommendationLabel(target) {

--- a/frontend/components/explore/PackValueHistoryChart.jsx
+++ b/frontend/components/explore/PackValueHistoryChart.jsx
@@ -42,6 +42,16 @@ function firstFiniteNumber(raw, keys) {
   return null;
 }
 
+function firstFiniteMetric(raw, keys) {
+  for (const key of keys) {
+    const value = toNumber(raw?.[key]);
+    if (value !== null) {
+      return { key, value };
+    }
+  }
+  return { key: null, value: null };
+}
+
 function formatRatio(value) {
   const parsed = toNumber(value);
   if (parsed === null) {
@@ -85,28 +95,73 @@ function resolveDollarValue(explicitValue, ratioValue, packCostValue) {
   return ratio * packCost;
 }
 
+function normalizeReturnMetrics(ratioValue, explicitValue, packCostValue) {
+  const ratio = toNumber(ratioValue);
+  const explicit = toNumber(explicitValue);
+  const packCost = toNumber(packCostValue);
+
+  if (explicit !== null) {
+    return {
+      returnValue: explicit,
+      ratioValue: packCost !== null && packCost > 0 ? explicit / packCost : null,
+    };
+  }
+
+  if (ratio === null || ratio < 0) {
+    return {
+      returnValue: null,
+      ratioValue: null,
+    };
+  }
+
+  return {
+    returnValue: packCost !== null && packCost > 0 ? ratio * packCost : null,
+    ratioValue: ratio,
+  };
+}
+
 function normalizeHistoryPoint(raw, index, fallbackPackCost) {
-  const meanCostRatio = firstFiniteNumber(raw, [
-    "simulated_mean_pack_value_vs_pack_cost",
-    "mean_cost_ratio",
+  const meanRatioMetric = firstFiniteMetric(raw, [
     "mean_value_to_cost_ratio",
+    "mean_cost_ratio",
+    "average_return_vs_cost",
+    "average_return_ratio",
+    "simulated_mean_value_to_cost_ratio",
+    "simulated_mean_pack_value_vs_pack_cost",
   ]);
-  const medianCostRatio = firstFiniteNumber(raw, [
-    "simulated_median_pack_value_vs_pack_cost",
-    "median_cost_ratio",
+  const medianRatioMetric = firstFiniteMetric(raw, [
     "median_value_to_cost_ratio",
+    "median_cost_ratio",
+    "typical_value_to_cost_ratio",
+    "typical_return_vs_cost",
+    "typical_return_ratio",
+    "simulated_median_value_to_cost_ratio",
+    "simulated_median_pack_value_vs_pack_cost",
   ]);
   const p95CostRatio = firstFiniteNumber(raw, [
     "p95_value_to_cost_ratio",
     "p95_cost_ratio",
+    "big_hit_upside_ratio",
   ]);
   const packCostValue = firstFiniteNumber(raw, ["pack_cost", "packCost", "cost"]) ?? toNumber(fallbackPackCost);
 
-  // Audited backend view currently provides ratio fields for history_trend.
-  // Keep direct-value keys strict to avoid treating unrelated zero defaults as real values.
-  const meanValueDirect = firstFiniteNumber(raw, ["simulated_mean_pack_value", "mean_pack_value", "mean_value"]);
-  const medianValueDirect = firstFiniteNumber(raw, ["simulated_median_pack_value", "median_pack_value", "median_value"]);
-  const p95ValueDirect = firstFiniteNumber(raw, ["simulated_p95_pack_value", "p95_pack_value", "p95_value"]);
+  // Prefer explicit gross values where available.
+  const meanValueDirect = firstFiniteNumber(raw, ["average_pack_value", "simulated_mean_pack_value", "mean_pack_value", "mean_value"]);
+  const medianValueDirect = firstFiniteNumber(raw, ["typical_pack_value", "simulated_median_pack_value", "median_pack_value", "median_value"]);
+  const p95ValueDirect = firstFiniteNumber(raw, ["big_hit_value", "simulated_p95_pack_value", "p95_pack_value", "p95_value"]);
+
+  // Treat legacy *_vs_pack_cost zero placeholders as missing when there is no direct gross value.
+  const meanRatioRaw =
+    meanRatioMetric.key === "simulated_mean_pack_value_vs_pack_cost" && meanRatioMetric.value === 0 && meanValueDirect === null
+      ? null
+      : meanRatioMetric.value;
+  const medianRatioRaw =
+    medianRatioMetric.key === "simulated_median_pack_value_vs_pack_cost" && medianRatioMetric.value === 0 && medianValueDirect === null
+      ? null
+      : medianRatioMetric.value;
+
+  const normalizedMean = normalizeReturnMetrics(meanRatioRaw, meanValueDirect, packCostValue);
+  const normalizedMedian = normalizeReturnMetrics(medianRatioRaw, medianValueDirect, packCostValue);
 
   return {
     id: `${index}:${raw?.snapshot_date || "na"}:${raw?.calculation_run_id || "na"}`,
@@ -115,11 +170,11 @@ function normalizeHistoryPoint(raw, index, fallbackPackCost) {
     runCreatedAt: raw?.run_created_at || null,
     calculationRunId: raw?.calculation_run_id || null,
     packCost: packCostValue,
-    meanCostRatio,
-    medianCostRatio,
+    meanCostRatio: normalizedMean.ratioValue,
+    medianCostRatio: normalizedMedian.ratioValue,
     p95CostRatio,
-    meanValue: resolveDollarValue(meanValueDirect, meanCostRatio, packCostValue),
-    medianValue: resolveDollarValue(medianValueDirect, medianCostRatio, packCostValue),
+    meanValue: normalizedMean.returnValue,
+    medianValue: normalizedMedian.returnValue,
     p95Value: resolveDollarValue(p95ValueDirect, p95CostRatio, packCostValue),
   };
 }
@@ -279,7 +334,7 @@ function LegendToggle({ active, onToggle, activeColor, inactiveColor, label }) {
 }
 
 // ─── Main chart ───────────────────────────────────────────────────────────────
-export default function PackValueHistoryChart({ historyTrend = [], packCost = null }) {
+export default function PackValueHistoryChart({ historyTrend = [], packCost = null, summary = null }) {
   const [showMeanLine,   setShowMeanLine]   = useState(true);
   const [showMedianLine, setShowMedianLine] = useState(true);
   const [showP95Line,    setShowP95Line]    = useState(true);
@@ -298,15 +353,48 @@ export default function PackValueHistoryChart({ historyTrend = [], packCost = nu
   );
 
   const chartData = useMemo(
-    () =>
-      (Array.isArray(historyTrend) ? historyTrend : [])
-        .map((row, index) => normalizeHistoryPoint(row, index, packCost))
-        .filter(
-          (row) =>
-            row.snapshotDate &&
-            (row.meanCostRatio !== null || row.medianCostRatio !== null)
-        ),
-    [historyTrend, packCost]
+    () => {
+      const normalizedRows = (Array.isArray(historyTrend) ? historyTrend : [])
+        .map((row, index) => normalizeHistoryPoint(row, index, packCost));
+
+      if (normalizedRows.length === 0) {
+        return [];
+      }
+
+      const latestRow = normalizedRows[normalizedRows.length - 1];
+      const effectiveLatestPackCost = toNumber(latestRow.packCost) ?? toNumber(summary?.pack_cost) ?? toNumber(packCost);
+      const meanValueSummary = firstFiniteNumber(summary, ["average_pack_value", "simulated_mean_pack_value", "mean_pack_value", "mean_value"]);
+      const medianValueSummary = firstFiniteNumber(summary, ["typical_pack_value", "simulated_median_pack_value", "median_pack_value", "median_value"]);
+
+      const meanRatioSummary =
+        firstFiniteNumber(summary, ["mean_value_to_cost_ratio", "mean_cost_ratio", "average_return_ratio"]) ??
+        (meanValueSummary !== null && effectiveLatestPackCost !== null && effectiveLatestPackCost > 0
+          ? meanValueSummary / effectiveLatestPackCost
+          : null);
+
+      const medianRatioSummary =
+        firstFiniteNumber(summary, ["median_value_to_cost_ratio", "median_cost_ratio", "typical_return_ratio"]) ??
+        (medianValueSummary !== null && effectiveLatestPackCost !== null && effectiveLatestPackCost > 0
+          ? medianValueSummary / effectiveLatestPackCost
+          : null);
+
+      const patchedLatestRow = {
+        ...latestRow,
+        meanCostRatio: latestRow.meanCostRatio ?? meanRatioSummary,
+        medianCostRatio: latestRow.medianCostRatio ?? medianRatioSummary,
+        meanValue:
+          latestRow.meanValue ??
+          (meanRatioSummary !== null && effectiveLatestPackCost !== null ? meanRatioSummary * effectiveLatestPackCost : null),
+        medianValue:
+          latestRow.medianValue ??
+          (medianRatioSummary !== null && effectiveLatestPackCost !== null ? medianRatioSummary * effectiveLatestPackCost : null),
+      };
+
+      return [...normalizedRows.slice(0, -1), patchedLatestRow].filter(
+        (row) => row.snapshotDate && (row.meanCostRatio !== null || row.medianCostRatio !== null)
+      );
+    },
+    [historyTrend, packCost, summary]
   );
 
   // Determine whether any row actually has P95 data so we can hide the toggle

--- a/frontend/components/explore/PackValueHistoryChart.jsx
+++ b/frontend/components/explore/PackValueHistoryChart.jsx
@@ -14,6 +14,10 @@ import {
 } from "recharts";
 
 import InfoPopover from "@/components/ui/InfoPopover";
+import {
+  normalizeHistoryTrendPoint,
+  patchLatestHistoryRowWithSummaryRatios,
+} from "./packValueHistoryNormalization.mjs";
 
 // ─── Color tokens for this chart only ────────────────────────────────────────
 const HISTORICAL_TREND_COLORS = {
@@ -121,62 +125,7 @@ function normalizeReturnMetrics(ratioValue, explicitValue, packCostValue) {
 }
 
 function normalizeHistoryPoint(raw, index, fallbackPackCost) {
-  const meanRatioMetric = firstFiniteMetric(raw, [
-    "mean_value_to_cost_ratio",
-    "mean_cost_ratio",
-    "average_return_vs_cost",
-    "average_return_ratio",
-    "simulated_mean_value_to_cost_ratio",
-    "simulated_mean_pack_value_vs_pack_cost",
-  ]);
-  const medianRatioMetric = firstFiniteMetric(raw, [
-    "median_value_to_cost_ratio",
-    "median_cost_ratio",
-    "typical_value_to_cost_ratio",
-    "typical_return_vs_cost",
-    "typical_return_ratio",
-    "simulated_median_value_to_cost_ratio",
-    "simulated_median_pack_value_vs_pack_cost",
-  ]);
-  const p95CostRatio = firstFiniteNumber(raw, [
-    "p95_value_to_cost_ratio",
-    "p95_cost_ratio",
-    "big_hit_upside_ratio",
-  ]);
-  const packCostValue = firstFiniteNumber(raw, ["pack_cost", "packCost", "cost"]) ?? toNumber(fallbackPackCost);
-
-  // Prefer explicit gross values where available.
-  const meanValueDirect = firstFiniteNumber(raw, ["average_pack_value", "simulated_mean_pack_value", "mean_pack_value", "mean_value"]);
-  const medianValueDirect = firstFiniteNumber(raw, ["typical_pack_value", "simulated_median_pack_value", "median_pack_value", "median_value"]);
-  const p95ValueDirect = firstFiniteNumber(raw, ["big_hit_value", "simulated_p95_pack_value", "p95_pack_value", "p95_value"]);
-
-  // Treat legacy *_vs_pack_cost zero placeholders as missing when there is no direct gross value.
-  const meanRatioRaw =
-    meanRatioMetric.key === "simulated_mean_pack_value_vs_pack_cost" && meanRatioMetric.value === 0 && meanValueDirect === null
-      ? null
-      : meanRatioMetric.value;
-  const medianRatioRaw =
-    medianRatioMetric.key === "simulated_median_pack_value_vs_pack_cost" && medianRatioMetric.value === 0 && medianValueDirect === null
-      ? null
-      : medianRatioMetric.value;
-
-  const normalizedMean = normalizeReturnMetrics(meanRatioRaw, meanValueDirect, packCostValue);
-  const normalizedMedian = normalizeReturnMetrics(medianRatioRaw, medianValueDirect, packCostValue);
-
-  return {
-    id: `${index}:${raw?.snapshot_date || "na"}:${raw?.calculation_run_id || "na"}`,
-    rawPoint: raw,
-    snapshotDate: raw?.snapshot_date || null,
-    runCreatedAt: raw?.run_created_at || null,
-    calculationRunId: raw?.calculation_run_id || null,
-    packCost: packCostValue,
-    meanCostRatio: normalizedMean.ratioValue,
-    medianCostRatio: normalizedMedian.ratioValue,
-    p95CostRatio,
-    meanValue: normalizedMean.returnValue,
-    medianValue: normalizedMedian.returnValue,
-    p95Value: resolveDollarValue(p95ValueDirect, p95CostRatio, packCostValue),
-  };
+  return normalizeHistoryTrendPoint(raw, index, fallbackPackCost);
 }
 
 /**
@@ -367,28 +316,22 @@ export default function PackValueHistoryChart({ historyTrend = [], packCost = nu
       const medianValueSummary = firstFiniteNumber(summary, ["typical_pack_value", "simulated_median_pack_value", "median_pack_value", "median_value"]);
 
       const meanRatioSummary =
-        firstFiniteNumber(summary, ["mean_value_to_cost_ratio", "mean_cost_ratio", "average_return_ratio"]) ??
+        firstFiniteNumber(summary, ["mean_value_to_cost_ratio", "average_return_vs_cost", "mean_cost_ratio", "average_return_ratio"]) ??
         (meanValueSummary !== null && effectiveLatestPackCost !== null && effectiveLatestPackCost > 0
           ? meanValueSummary / effectiveLatestPackCost
           : null);
 
       const medianRatioSummary =
-        firstFiniteNumber(summary, ["median_value_to_cost_ratio", "median_cost_ratio", "typical_return_ratio"]) ??
+        firstFiniteNumber(summary, ["median_value_to_cost_ratio", "typical_return_vs_cost", "typical_value_to_cost_ratio", "median_cost_ratio", "typical_return_ratio"]) ??
         (medianValueSummary !== null && effectiveLatestPackCost !== null && effectiveLatestPackCost > 0
           ? medianValueSummary / effectiveLatestPackCost
           : null);
 
-      const patchedLatestRow = {
-        ...latestRow,
-        meanCostRatio: latestRow.meanCostRatio ?? meanRatioSummary,
-        medianCostRatio: latestRow.medianCostRatio ?? medianRatioSummary,
-        meanValue:
-          latestRow.meanValue ??
-          (meanRatioSummary !== null && effectiveLatestPackCost !== null ? meanRatioSummary * effectiveLatestPackCost : null),
-        medianValue:
-          latestRow.medianValue ??
-          (medianRatioSummary !== null && effectiveLatestPackCost !== null ? medianRatioSummary * effectiveLatestPackCost : null),
-      };
+      const patchedLatestRow = patchLatestHistoryRowWithSummaryRatios(latestRow, {
+        meanRatioSummary,
+        medianRatioSummary,
+        effectivePackCost: effectiveLatestPackCost,
+      });
 
       return [...normalizedRows.slice(0, -1), patchedLatestRow].filter(
         (row) => row.snapshotDate && (row.meanCostRatio !== null || row.medianCostRatio !== null)

--- a/frontend/components/explore/RipStatisticsPageClient.jsx
+++ b/frontend/components/explore/RipStatisticsPageClient.jsx
@@ -14,6 +14,7 @@ import RankBadge from "@/components/ui/RankBadge";
 import { RANK_CONFIG } from "@/constants/rankConfig";
 import { getFriendlyMetricLabel, getScoreTootip, getFormattedTooltip, getMetricTooltip } from "@/constants/interpretabilityConfig";
 import { getCalloutAccentStyle, getDangerValueStyle, getInterpretationTone } from "@/lib/explore/interpretationTone";
+import { getPokemonSetCards } from "@/lib/pokemon/pokemonSetCardsClient";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
   style: "currency",
@@ -24,7 +25,7 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
 
 const REQUIRED_PACK_PATHS = ["normal", "demi_god_pack", "god_pack"];
 const ANALYSIS_SECTION_ID = "explore-outcomes";
-const GRAPH_SECTION_KEYS = new Set(["outcome-distribution", "historical-trend", "pack-breakdown"]);
+const GRAPH_SECTION_KEYS = new Set(["outcome-distribution", "historical-trend", "pack-breakdown", "value-contribution"]);
 const SECTION_ID_MAP = {
   "pack-score": "explore-score",
   "outcome-distribution": "explore-outcomes",
@@ -50,6 +51,7 @@ const RIP_COPY = {
   simpleMetrics: {
     chanceToBeatPackCost: "Chance to Beat Pack Cost",
     averagePackValue: "Average Pack Value",
+    averageHitValue: "Average Hit Value",
     currentPackCost: "Estimated Pack Market Price",
     averageLoss: "Average Loss",
     chanceAtBigPull: "Chance at a Big Pull",
@@ -104,6 +106,16 @@ const SIMPLE_PILLAR_INFO_COPY = {
 function toNumber(value) {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function getFirstNumericValue(source, keys = []) {
+  for (const key of keys) {
+    const value = toNumber(source?.[key]);
+    if (value !== null) {
+      return value;
+    }
+  }
+  return null;
 }
 
 function normalizeProbability(value) {
@@ -171,6 +183,55 @@ function formatMultiplier(value, decimals = 1) {
     return "—";
   }
   return `${parsed.toFixed(decimals)}x`;
+}
+
+function getCardInitials(value) {
+  const text = String(value || "").trim();
+  if (!text) {
+    return "?";
+  }
+  const words = text.split(/\s+/).filter(Boolean);
+  if (words.length === 1) {
+    return words[0].slice(0, 2).toUpperCase();
+  }
+  return `${words[0][0] || ""}${words[1][0] || ""}`.toUpperCase();
+}
+
+function ChecklistCardTile({ card }) {
+  const imageUrl = card?.imageSmallUrl || card?.imageLargeUrl || null;
+  const name = card?.name || "Unknown card";
+  const number = card?.cardNumber || null;
+  const rarity = card?.rarity || null;
+  const marketPrice = Number.isFinite(card?.marketPrice) ? currencyFormatter.format(card.marketPrice) : null;
+
+  return (
+    <article className="overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-page)]/55 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.02),0_8px_18px_rgba(2,6,23,0.14)]">
+      <div className="relative aspect-[3/4] w-full border-b border-[var(--border-subtle)] bg-[var(--surface-panel)]/80">
+        {imageUrl ? (
+          <img
+            src={imageUrl}
+            alt={name}
+            className="h-full w-full object-cover"
+            loading="lazy"
+            decoding="async"
+          />
+        ) : (
+          <div className="flex h-full w-full flex-col items-center justify-center gap-1 px-3 text-center text-[var(--text-secondary)]">
+            <span className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[var(--border-subtle)] bg-[var(--surface-page)] text-xs font-semibold uppercase tracking-[0.06em] text-[var(--text-primary)]">
+              {getCardInitials(name)}
+            </span>
+            <p className="line-clamp-2 text-xs">{name}</p>
+          </div>
+        )}
+      </div>
+      <div className="space-y-1.5 px-3 py-3">
+        <p className="line-clamp-2 text-sm font-semibold leading-snug text-[var(--text-primary)]">{name}</p>
+        {number ? <p className="text-xs text-[var(--text-secondary)]">No. {number}</p> : null}
+        {rarity ? <p className="text-xs text-[var(--text-secondary)]">{rarity}</p> : null}
+        {marketPrice ? <p className="text-xs font-medium text-[var(--text-primary)]">Market: {marketPrice}</p> : null}
+      </div>
+    </article>
+  );
 }
 
 function normalizePullRateAssumptions(explorePayload) {
@@ -417,15 +478,18 @@ function MetricRow({ label, value, infoText }) {
 
 function HeroMetricTile({ label, value }) {
   const friendlyLabel = getFriendlyMetricLabel(label);
-  const infoText = getMetricTooltip(label);
+  const infoText =
+    label === RIP_COPY.simpleMetrics.averageHitValue
+      ? "Average value of packs that contain a meaningful hit, excluding normal low-value outcomes."
+      : getMetricTooltip(label);
   const isNegativeValue = typeof value === "string" && value.trim().startsWith("-");
   return (
-    <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-page)]/60 p-3">
+    <div className="rounded-xl border border-[var(--border-subtle)] bg-[color:color-mix(in_srgb,var(--surface-page)_78%,transparent)] p-3 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.03),0_8px_20px_rgba(2,6,23,0.12)] backdrop-blur-[2px]">
       <div className="flex items-start justify-between gap-2">
-        <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)]">{friendlyLabel}</p>
+        <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[color:color-mix(in_srgb,var(--text-primary)_72%,var(--text-secondary))]">{friendlyLabel}</p>
         {infoText ? <InfoPopover text={infoText} /> : null}
       </div>
-      <p className="mt-2 text-base font-semibold" style={isNegativeValue ? getDangerValueStyle() : { color: "var(--text-primary)" }}>
+      <p className="mt-2 text-lg font-bold leading-tight [text-shadow:0_1px_1px_rgba(2,6,23,0.22)]" style={isNegativeValue ? getDangerValueStyle() : { color: "var(--text-primary)" }}>
         {value}
       </p>
     </div>
@@ -1844,6 +1908,9 @@ export default function RipStatisticsPageClient({
   requestedTargetId,
   explorePayload,
   pageError,
+  profileBaseHref = "/Explore/rip-statistics",
+  targetHrefById = null,
+  setDetailMode = false,
 }) {
   const router = useRouter();
   const pathname = usePathname();
@@ -1906,11 +1973,20 @@ export default function RipStatisticsPageClient({
   const [viewMode, setViewMode] = useState("simple");
   const [heroMetricView, setHeroMetricView] = useState("overview");
   const [activeValueView, setActiveValueView] = useState("cards");
-  const isExpertMode = viewMode === "expert";
-  const effectiveValueView = isExpertMode ? activeValueView : "cards";
+  const effectiveViewMode = setDetailMode ? "expert" : viewMode;
+  const isExpertMode = effectiveViewMode === "expert";
+  const effectiveValueView = setDetailMode ? "value" : isExpertMode ? activeValueView : "cards";
   const [activeSection, setActiveSection] = useState("pack-score");
   const [heroSetPickerOpen, setHeroSetPickerOpen] = useState(false);
+  const [setDetailTab, setSetDetailTab] = useState("cards");
+  const [cardsSubTab, setCardsSubTab] = useState("checklist");
+  const [checklistState, setChecklistState] = useState({
+    status: "idle",
+    cards: [],
+    error: null,
+  });
   const heroSetPickerRef = useRef(null);
+  const checklistCacheRef = useRef(new Map());
   const pendingNavSelectionRef = useRef(null);
   const pendingNavTimeoutRef = useRef(null);
   const pendingNavStartedAtRef = useRef(0);
@@ -1920,6 +1996,8 @@ export default function RipStatisticsPageClient({
       ? historicalTrendMeta
       : graphMode === "pack-breakdown"
       ? packBreakdownMeta
+      : graphMode === "value-contribution"
+      ? rarityContributionMeta
       : outcomeDistributionMeta;
 
   const graphSectionFallback =
@@ -1927,6 +2005,8 @@ export default function RipStatisticsPageClient({
       ? interpretation?.historicalTrend
       : graphMode === "pack-breakdown"
       ? interpretation?.packBreakdown
+      : graphMode === "value-contribution"
+      ? interpretation?.rarityContribution
       : interpretation?.outcomeDistribution;
 
   const outcomeDistributionInfo = (
@@ -1981,7 +2061,7 @@ export default function RipStatisticsPageClient({
     ],
     []
   );
-  const displayedSectionNavItems = viewMode === "simple"
+  const displayedSectionNavItems = effectiveViewMode === "simple"
     ? [{ id: "pack-score", label: RIP_COPY.sections.packScore }]
     : sectionNavItems;
 
@@ -2228,9 +2308,31 @@ export default function RipStatisticsPageClient({
   const recommendationBadge = packScoreMeta?.label || null;
   const recommendationTone = getInterpretationTone({ label: recommendationBadge, rankTier: summary.pack_tier });
   const simpleAverageLossValue = getSimpleAverageLossValue(summary);
+  const averageHitValue = getFirstNumericValue(summary, [
+    "average_hit_value",
+    "hit_average_value",
+    "average_value_when_hit",
+    "big_pull_average",
+    "hit_pack_average_value",
+    "average_hit_pack_value",
+    "average_pack_value_of_hits",
+  ]);
+  const setValue = getFirstNumericValue(summary, [
+    "set_value",
+    "total_set_value",
+    "total_card_value",
+    "set_market_value",
+    "collection_value",
+    "total_value",
+  ]);
+
+  const averageHitValueDisplay = averageHitValue === null ? "Coming soon" : formatCurrency(averageHitValue);
+  const setValueDisplay = setValue === null ? "Coming soon" : formatCurrency(setValue);
+
   const decisionMetrics = [
     { label: RIP_COPY.simpleMetrics.currentPackCost, value: formatCurrency(summary.pack_cost) },
     { label: RIP_COPY.simpleMetrics.averagePackValue, value: formatCurrency(summary.mean_value) },
+    { label: RIP_COPY.simpleMetrics.averageHitValue, value: averageHitValueDisplay },
     { label: RIP_COPY.simpleMetrics.averageLoss, value: formatSignedCurrency(simpleAverageLossValue) },
     { label: RIP_COPY.simpleMetrics.chanceToBeatPackCost, value: formatPercent(summary.prob_profit, { probability: true }) },
     { label: RIP_COPY.simpleMetrics.chanceAtBigPull, value: formatPercent(summary.prob_big_hit, { probability: true }) },
@@ -2238,6 +2340,7 @@ export default function RipStatisticsPageClient({
   const primaryDecisionMetricOrder = [
     RIP_COPY.simpleMetrics.currentPackCost,
     RIP_COPY.simpleMetrics.averagePackValue,
+    RIP_COPY.simpleMetrics.averageHitValue,
     RIP_COPY.simpleMetrics.averageLoss,
   ];
   const primaryDecisionMetrics = primaryDecisionMetricOrder
@@ -2265,10 +2368,17 @@ export default function RipStatisticsPageClient({
       options.closeToolsPanel();
     }
 
-    const nextParams = new URLSearchParams(searchParams?.toString() || "");
-    nextParams.set("target_type", requestedTargetType || "set");
-    nextParams.set("target_id", nextTargetId);
+    const nextHref = targetHrefById?.[nextTargetId] || null;
+
     startTransition(() => {
+      if (nextHref) {
+        router.push(nextHref);
+        return;
+      }
+
+      const nextParams = new URLSearchParams(searchParams?.toString() || "");
+      nextParams.set("target_type", requestedTargetType || "set");
+      nextParams.set("target_id", nextTargetId);
       router.push(`${pathname}?${nextParams.toString()}`);
     });
   };
@@ -2309,6 +2419,59 @@ export default function RipStatisticsPageClient({
   useEffect(() => {
     setHeroSetPickerOpen(false);
   }, [requestedTargetId]);
+
+  useEffect(() => {
+    if (!setDetailMode || setDetailTab !== "cards" || cardsSubTab !== "checklist") {
+      return undefined;
+    }
+
+    const setId = String(requestedTargetId || "").trim();
+    if (!setId) {
+      setChecklistState({ status: "empty", cards: [], error: null });
+      return undefined;
+    }
+
+    const cached = checklistCacheRef.current.get(setId);
+    if (cached) {
+      setChecklistState({ status: "success", cards: cached, error: null });
+      return undefined;
+    }
+
+    let isCancelled = false;
+    setChecklistState((previous) => ({
+      status: "loading",
+      cards: previous.status === "success" ? previous.cards : [],
+      error: null,
+    }));
+
+    getPokemonSetCards(setId)
+      .then((payload) => {
+        if (isCancelled) {
+          return;
+        }
+        const cards = Array.isArray(payload?.cards) ? payload.cards : [];
+        checklistCacheRef.current.set(setId, cards);
+        setChecklistState({
+          status: cards.length > 0 ? "success" : "empty",
+          cards,
+          error: null,
+        });
+      })
+      .catch((error) => {
+        if (isCancelled) {
+          return;
+        }
+        setChecklistState({
+          status: "error",
+          cards: [],
+          error: error?.message || "Unable to load cards for this set.",
+        });
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [setDetailMode, setDetailTab, cardsSubTab, requestedTargetId]);
 
   const desktopSidebarContent = (
     <div className="space-y-5 rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-page)]/72 p-4 backdrop-blur-sm">
@@ -2436,25 +2599,25 @@ export default function RipStatisticsPageClient({
   return (
     <main className="w-full max-w-full pb-8 pt-0 lg:py-8">
       <PublicProfileLocalScaffold
-        profileBaseHref="/Explore/rip-statistics"
+        profileBaseHref={profileBaseHref}
         mode="public"
         sectionItems={[]}
         mobileNavItems={[]}
-        desktopSidebarContent={desktopSidebarContent}
-        mobileToolsPanelContent={renderMobileToolsPanelContent}
+        desktopSidebarContent={setDetailMode ? null : desktopSidebarContent}
+        mobileToolsPanelContent={setDetailMode ? null : renderMobileToolsPanelContent}
         mobileToolsTitle="Explore Filters & Navigation"
         mobileToolsDescription="Switch TCG and set filters."
         mobileToolsPanelAriaLabel="Explore filters and navigation"
         mobileToolsTriggerLabel="Filters & Tools"
         mobileToolsTriggerTitle="Open filters and navigation"
-        useFloatingToolsOnTablet
-        forceCompactToolsBelow2xl
+        useFloatingToolsOnTablet={!setDetailMode}
+        forceCompactToolsBelow2xl={!setDetailMode}
         centerContentIgnoringSidebar
         desktopContentOffsetClassName="xl:flex xl:justify-center"
         wrapDesktopContentInFrame={false}
         mobileBottomNavVariant="flat"
         mobileBottomNavContent={() => (
-          viewMode === "expert" ? (
+          !setDetailMode && effectiveViewMode === "expert" ? (
             <CompactBottomSectionNav
               activeSection={activeSection}
               onSelect={handleSectionSelect}
@@ -2462,7 +2625,13 @@ export default function RipStatisticsPageClient({
           ) : null
         )}
       >
-        <div className="dashboard-container space-y-8 w-full max-w-full min-w-0 !p-0 !bg-transparent !border-0 !rounded-none xl:!p-6 xl:!bg-[rgba(255,255,255,0.02)] xl:!rounded-2xl xl:!border">
+        <div
+          className={`dashboard-container w-full max-w-full min-w-0 !p-0 !bg-transparent !border-0 !rounded-none ${
+            setDetailMode
+              ? "mx-auto max-w-7xl space-y-4 xl:!p-0 xl:!bg-transparent xl:!rounded-none xl:!border-0"
+              : "space-y-8 xl:!p-6 xl:!bg-[rgba(255,255,255,0.02)] xl:!rounded-2xl xl:!border"
+          }`}
+        >
         {pageError ? (
           <section className="rounded-2xl border border-red-500/30 bg-[var(--surface-panel)] p-5 sm:p-6">
             <p className="text-base font-semibold text-[var(--text-primary)]">RIP Statistics unavailable</p>
@@ -2472,6 +2641,234 @@ export default function RipStatisticsPageClient({
 
         {!pageError && explorePayload ? (
           <>
+            {setDetailMode ? (
+              <>
+                <section className="page-hero-panel relative overflow-visible rounded-xl px-4 py-4 md:rounded-2xl md:px-6 md:py-5">
+                  <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden rounded-xl md:rounded-2xl">
+                    {heroLogoUrl ? (
+                      <div className="absolute left-1/2 top-1/2 h-[112%] w-[112%] -translate-x-1/2 -translate-y-1/2 select-none">
+                        <img
+                          src={heroLogoUrl}
+                          alt=""
+                          aria-hidden="true"
+                          className="h-full w-full object-contain opacity-[0.08] [filter:drop-shadow(0_0_20px_rgba(148,163,184,0.12))]"
+                          loading="lazy"
+                          decoding="async"
+                        />
+                      </div>
+                    ) : null}
+                  </div>
+
+                  <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-4">
+                    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.7fr)] lg:items-stretch">
+                      <div className="flex h-full min-h-full flex-col gap-3">
+                      <div ref={heroSetPickerRef} data-hero-picker className="relative z-20 rounded-xl border border-[var(--border-subtle)] bg-[color:color-mix(in_srgb,var(--surface-page)_78%,transparent)] p-4 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.03),0_8px_20px_rgba(2,6,23,0.12)] backdrop-blur-[2px]">
+                        <CenteredSuffixInline
+                          as="button"
+                          type="button"
+                          onClick={() => setHeroSetPickerOpen((open) => !open)}
+                          disabled={isPending || targets.length === 0}
+                          aria-expanded={heroSetPickerOpen}
+                          aria-haspopup="listbox"
+                          aria-controls="hero-set-picker-list"
+                          className="block w-full rounded-lg px-2 py-0 text-left text-xl font-semibold text-[var(--text-primary)] transition-colors hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] md:text-2xl disabled:cursor-not-allowed disabled:opacity-90"
+                          contentClassName="max-w-full whitespace-normal break-words leading-tight"
+                          suffixWrapperClassName="right-1"
+                          suffix={
+                            <svg
+                              aria-hidden="true"
+                              viewBox="0 0 20 20"
+                              className={`h-4 w-4 flex-none text-[var(--text-secondary)] transition-transform ${heroSetPickerOpen ? "rotate-180" : ""}`}
+                              fill="currentColor"
+                            >
+                              <path d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.12l3.71-3.89a.75.75 0 1 1 1.08 1.04l-4.25 4.45a.75.75 0 0 1-1.08 0L5.21 8.27a.75.75 0 0 1 .02-1.06Z" />
+                            </svg>
+                          }
+                          title={targets.length > 0 ? "Switch set" : "No sets available"}
+                        >
+                          <span>{selectedName}</span>
+                        </CenteredSuffixInline>
+
+                        {heroSetPickerOpen ? (
+                          <div
+                            id="hero-set-picker-list"
+                            role="listbox"
+                            aria-label="Available sets"
+                            className="index-scrollbar absolute left-0 top-[calc(100%+0.5rem)] z-50 max-h-56 w-full max-w-full overflow-y-auto rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-panel)] p-1.5 text-left shadow-[0_14px_34px_rgba(0,0,0,0.45)]"
+                          >
+                            {targets.map((target) => {
+                              const isSelected = String(target.target_id) === String(requestedTargetId || "");
+                              return (
+                                <button
+                                  key={`hero-set-option:${target.target_type}:${target.target_id}`}
+                                  type="button"
+                                  role="option"
+                                  aria-selected={isSelected}
+                                  onClick={() => {
+                                    handleTargetIdChange(String(target.target_id || ""));
+                                    setHeroSetPickerOpen(false);
+                                  }}
+                                  className={`flex w-full items-center justify-between gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 transition-colors ${
+                                    isSelected
+                                      ? "bg-[var(--surface-page)] text-[var(--text-primary)]"
+                                      : "text-[var(--text-secondary)] hover:bg-[var(--surface-page)]/70 hover:text-[var(--text-primary)]"
+                                  }`}
+                                >
+                                  <span className="min-w-0 flex-1 truncate whitespace-nowrap">{target.name}</span>
+                                  {isSelected ? (
+                                    <span className="shrink-0 text-xs font-medium text-[var(--accent)]">Current</span>
+                                  ) : null}
+                                </button>
+                              );
+                            })}
+                          </div>
+                        ) : null}
+
+                        <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-secondary)]">{RIP_COPY.scoreLabel}</p>
+                        <div className="mt-2 flex items-end gap-2">
+                          <span className="text-5xl font-semibold leading-none tracking-[-0.04em] text-[var(--text-primary)] md:text-6xl">{displayedTopScore}</span>
+                          <span className="pb-1 text-xs font-medium text-[var(--text-secondary)]">/100</span>
+                        </div>
+                        <div className="mt-3">
+                          <ScoreMeter score={topScoreRaw} rankTier={summary.pack_tier} />
+                        </div>
+                        <div className="mt-3 flex items-center gap-2">
+                          <RankBadge
+                            rank={summary.pack_tier}
+                            label="Rank"
+                            size="md"
+                            title={
+                              summary.pack_rank === null || summary.pack_rank === undefined
+                                ? "Rank unavailable"
+                                : `Rank #${summary.pack_rank}`
+                            }
+                          />
+                          <RecommendationBadge label={recommendationBadge} rankTier={summary.pack_tier} />
+                        </div>
+                      </div>
+
+                      <div className="flex min-h-[8.25rem] flex-1 flex-col rounded-xl border border-[var(--border-subtle)] bg-[color:color-mix(in_srgb,var(--surface-page)_78%,transparent)] p-4 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.03),0_8px_20px_rgba(2,6,23,0.12)] backdrop-blur-[2px]">
+                        <div className="flex items-start justify-between gap-2">
+                          <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[color:color-mix(in_srgb,var(--text-primary)_72%,var(--text-secondary))]">Set Value</p>
+                        </div>
+                        <p className="mt-2 text-lg font-bold text-[var(--text-primary)] [text-shadow:0_1px_1px_rgba(2,6,23,0.18)]">{setValueDisplay}</p>
+                        <p className="mt-auto pt-1 text-xs text-[var(--text-secondary)]">Trend coming soon</p>
+                      </div>
+                      </div>
+
+                      <div className="flex h-full flex-col justify-between gap-2.5">
+                        <div
+                          className="rounded-xl border-l-2 border-[var(--border-subtle)] bg-[var(--surface-page)]/55 px-4 py-3"
+                          style={getCalloutAccentStyle({ label: recommendationBadge, rankTier: summary.pack_tier })}
+                        >
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-secondary)]">{RIP_COPY.recommendationLabel}</p>
+                          <p className="mt-1.5 text-sm text-[var(--text-primary)]">{recommendationSummary || "No interpretation summary is available for this set yet."}</p>
+                        </div>
+
+                        <div className="grid gap-2.5 sm:grid-cols-2 lg:grid-cols-3">
+                          {decisionMetrics.map((metric) => (
+                            <HeroMetricTile key={`set-compact-${metric.label}`} label={metric.label} value={metric.value} />
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </section>
+
+                <SectionViewTabs
+                  value={setDetailTab}
+                  onChange={setSetDetailTab}
+                  options={[
+                    { value: "cards", label: "Cards" },
+                    { value: "pull-rates", label: "Pull Rates" },
+                    { value: "analytics", label: "Analytics" },
+                  ]}
+                />
+
+                {setDetailTab === "cards" ? (
+                  <section className="space-y-3 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-panel)]/70 p-4 md:p-5">
+                    <SectionViewTabs
+                      value={cardsSubTab}
+                      onChange={setCardsSubTab}
+                      options={[
+                        { value: "checklist", label: "Checklist" },
+                        { value: "simulated-impact", label: "Simulated Impact" },
+                      ]}
+                    />
+
+                    {cardsSubTab === "checklist" ? (
+                      <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-page)]/45 px-4 py-4">
+                        {checklistState.status === "loading" ? (
+                          <p className="text-sm text-[var(--text-secondary)]">Loading cards...</p>
+                        ) : null}
+
+                        {checklistState.status === "error" ? (
+                          <p className="text-sm text-red-300">{checklistState.error || "Unable to load cards for this set."}</p>
+                        ) : null}
+
+                        {checklistState.status === "empty" ? (
+                          <p className="text-sm text-[var(--text-secondary)]">No cards found for this set.</p>
+                        ) : null}
+
+                        {checklistState.status === "success" ? (
+                          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-4">
+                            {checklistState.cards.map((card) => (
+                              <ChecklistCardTile
+                                key={`${card.id || card.cardNumber || card.name}`}
+                                card={card}
+                              />
+                            ))}
+                          </div>
+                        ) : null}
+                      </div>
+                    ) : (
+                      <SectionCard
+                        title="Simulated Impact"
+                        subtitle="Cards ranked by how much they contribute to the simulated pack value."
+                      >
+                        <InterpretationInsight
+                          sectionMeta={topEvDriversMeta}
+                          fallbackSummary={collectorFriendlyText(interpretation?.topEvDrivers)}
+                          compact
+                          showEvidence={false}
+                          className="mb-3"
+                        />
+
+                        {topEvEvidenceRows.length > 0 ? (
+                          <div className="mb-3 flex max-w-full min-w-0 flex-wrap gap-x-2 gap-y-2">
+                            {topEvEvidenceRows.map(([label, value]) => (
+                              <span
+                                key={`${label}:${value}`}
+                                className="inline-flex max-w-full min-w-0 items-center gap-2 rounded-full border border-[var(--border-subtle)] bg-[var(--surface-page)]/55 px-2.5 py-1 text-xs text-[var(--text-secondary)]"
+                              >
+                                <span className="shrink-0">{label}</span>
+                                <span className="min-w-0 truncate font-medium text-[var(--text-primary)]">{String(value)}</span>
+                              </span>
+                            ))}
+                          </div>
+                        ) : null}
+
+                        <TopEVDriversContent topHits={topHits} meanValue={summary.mean_value} />
+                      </SectionCard>
+                    )}
+                  </section>
+                ) : null}
+
+                {setDetailTab === "pull-rates" ? (
+                  <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-panel)]/70 p-4 md:p-5">
+                    {pullRateAssumptions ? (
+                      <PullRateAssumptionsCard pullRateAssumptions={pullRateAssumptions} embedded />
+                    ) : (
+                      <p className="text-sm text-[var(--text-secondary)]">Pull-rate data coming soon for this set.</p>
+                    )}
+                  </section>
+                ) : null}
+              </>
+            ) : null}
+
+            {!setDetailMode || setDetailTab === "analytics" ? (
+              <>
+            {!setDetailMode ? (
             <section id="explore-score" style={{ scrollMarginTop: "calc(var(--app-header-offset,64px) + 4rem)" }} className="page-hero-panel relative overflow-hidden scroll-mt-24 rounded-xl px-4 py-6 md:rounded-2xl md:px-6 md:py-8 md:scroll-mt-28">
               {heroLogoUrl ? (
                 <div className="pointer-events-none absolute left-1/2 top-[18%] z-0 h-[100%] w-[100%] -translate-x-1/2 -translate-y-1/2 select-none sm:top-1/2 sm:h-[107%] sm:w-[107%]">
@@ -2602,7 +2999,7 @@ export default function RipStatisticsPageClient({
                     </div>
 
                     <div className="mx-auto mt-5 w-full max-w-5xl text-left">
-                      {viewMode === "simple" ? (
+                      {effectiveViewMode === "simple" ? (
                         <>
                           <div className="hidden lg:block">
                             <div className="mb-3 flex items-center gap-2">
@@ -2716,7 +3113,7 @@ export default function RipStatisticsPageClient({
                       )}
                     </div>
 
-                    {viewMode === "expert" ? (
+                    {effectiveViewMode === "expert" ? (
                       <>
                         <div className="mx-auto mt-4 w-full max-w-2xl">
                           <button
@@ -2733,8 +3130,9 @@ export default function RipStatisticsPageClient({
                 </div>
               </div>
             </section>
+            ) : null}
 
-            {viewMode === "simple" ? (
+            {effectiveViewMode === "simple" ? (
               <SetIntelligenceSection
                 summary={summary}
                 simpleMode
@@ -2742,7 +3140,7 @@ export default function RipStatisticsPageClient({
               />
             ) : null}
 
-            {viewMode === "simple" ? (
+            {effectiveViewMode === "simple" ? (
             <section id="explore-drivers" style={{ scrollMarginTop: "calc(var(--app-header-offset,64px) + 4rem)" }} className="w-full max-w-full min-w-0 scroll-mt-24 pt-1 md:scroll-mt-28">
               <SectionCard title={RIP_COPY.sections.rarityContribution} subtitle={null} titleInfoText={rarityContributionInfo}>
                 <div id="explore-rarity" style={{ scrollMarginTop: "calc(var(--app-header-offset,64px) + 4rem)" }} className="scroll-mt-24 md:scroll-mt-28" />
@@ -2774,8 +3172,8 @@ export default function RipStatisticsPageClient({
             </section>
             ) : null}
 
-            {viewMode === "expert" ? (
-            <section className="pt-8">
+            {effectiveViewMode === "expert" ? (
+            <section className="pt-4">
               <div className="grid gap-4 xl:grid-cols-3">
                 {/* Expert pillar metrics: Overview should be user-readable outcomes; Details should prioritize direct score inputs or close precursors. Context rows are allowed only when they clarify pillar behavior. Do not reuse hero Score Details mappings for pillar Details without ownership audit. */}
                 <ScorePillarCard
@@ -2847,7 +3245,7 @@ export default function RipStatisticsPageClient({
             </section>
             ) : null}
 
-            {viewMode === "expert" ? (
+            {effectiveViewMode === "expert" ? (
               <SetIntelligenceSection
                 summary={summary}
                 simpleMode={false}
@@ -2855,14 +3253,16 @@ export default function RipStatisticsPageClient({
               />
             ) : null}
 
-            {viewMode === "expert" ? (
-            <section id={ANALYSIS_SECTION_ID} style={{ scrollMarginTop: "calc(var(--app-header-offset,64px) + 4rem)" }} className="scroll-mt-24 pt-7 md:scroll-mt-28">
+            {effectiveViewMode === "expert" ? (
+            <section id={ANALYSIS_SECTION_ID} style={{ scrollMarginTop: "calc(var(--app-header-offset,64px) + 4rem)" }} className="scroll-mt-24 pt-4 md:scroll-mt-28">
               <SectionCard
                 title={
                   graphMode === "historical-trend"
                     ? RIP_COPY.sections.historicalTrend
                     : graphMode === "pack-breakdown"
                     ? RIP_COPY.sections.packBreakdown
+                    : graphMode === "value-contribution"
+                    ? "Value Contribution"
                     : RIP_COPY.sections.outcomeDistribution
                 }
                 subtitle={
@@ -2870,7 +3270,13 @@ export default function RipStatisticsPageClient({
                     ? "See where a typical pack lands, how often packs miss, and how far the best hits can run."
                     : null
                 }
-                titleInfoText={graphMode === "outcome-distribution" ? outcomeDistributionInfo : null}
+                titleInfoText={
+                  graphMode === "outcome-distribution"
+                    ? outcomeDistributionInfo
+                    : graphMode === "value-contribution"
+                    ? rarityContributionInfo
+                    : null
+                }
               >
                 <SectionViewTabs
                   className="mb-4"
@@ -2880,6 +3286,7 @@ export default function RipStatisticsPageClient({
                     { value: "outcome-distribution", label: RIP_COPY.sections.outcomeDistribution },
                     { value: "historical-trend", label: RIP_COPY.sections.historicalTrend },
                     { value: "pack-breakdown", label: RIP_COPY.sections.packBreakdown },
+                    ...(setDetailMode ? [{ value: "value-contribution", label: "Value Contribution" }] : []),
                   ]}
                 />
 
@@ -2906,7 +3313,7 @@ export default function RipStatisticsPageClient({
                 ) : null}
 
                 {graphMode === "historical-trend" ? (
-                  <PackValueHistoryChart historyTrend={historyTrend} packCost={summary.pack_cost} />
+                  <PackValueHistoryChart historyTrend={historyTrend} packCost={summary.pack_cost} summary={summary} />
                 ) : graphMode === "pack-breakdown" ? (
                   <div className="grid gap-5 md:grid-cols-2">
                     <div>
@@ -2918,11 +3325,19 @@ export default function RipStatisticsPageClient({
                       <StateBars stateRows={normalStateRows} />
                     </div>
                   </div>
+                ) : graphMode === "value-contribution" ? (
+                  <div className="space-y-3">
+                    <div>
+                      <p className="text-base font-semibold text-[var(--text-primary)]">Where the Value Comes From</p>
+                      <p className="mt-0.5 text-sm text-[var(--text-secondary)]">See how each rarity bucket contributes to modeled pack value in this simulation.</p>
+                    </div>
+                    <RarityContributionContent rankings={rankings} />
+                  </div>
                 ) : (
                   <RipDistributionChart bins={distributionBins} thresholdBins={thresholdBins} markers={chartMarkers} />
                 )}
 
-                {graphMode !== "pack-breakdown" ? (
+                {graphMode !== "pack-breakdown" && graphMode !== "value-contribution" ? (
                   <>
                     {graphMode === "historical-trend" ? (
                       <div className="mt-4 hidden gap-3 sm:grid-cols-3 lg:grid lg:grid-cols-6">
@@ -2971,19 +3386,21 @@ export default function RipStatisticsPageClient({
             </section>
             ) : null}
 
-            {viewMode === "expert" ? (
+            {effectiveViewMode === "expert" && !setDetailMode ? (
             <section id="explore-drivers" style={{ scrollMarginTop: "calc(var(--app-header-offset,64px) + 4rem)" }} className="w-full max-w-full min-w-0 scroll-mt-24 pt-1 md:scroll-mt-28">
               <SectionCard title={RIP_COPY.sections.rarityContribution} subtitle={null} titleInfoText={rarityContributionInfo}>
-                <SectionViewTabs
-                  className="mb-4"
-                  value={activeValueView}
-                  onChange={setActiveValueView}
-                  options={[
-                    { value: "cards", label: "Cards Carrying the Set" },
-                    { value: "value", label: "Value Contribution" },
-                    { value: "pull-rates", label: "Pull Rates" },
-                  ]}
-                />
+                {!setDetailMode ? (
+                  <SectionViewTabs
+                    className="mb-4"
+                    value={activeValueView}
+                    onChange={setActiveValueView}
+                    options={[
+                      { value: "cards", label: "Cards Carrying the Set" },
+                      { value: "value", label: "Value Contribution" },
+                      { value: "pull-rates", label: "Pull Rates" },
+                    ]}
+                  />
+                ) : null}
 
                 <div id="explore-rarity" style={{ scrollMarginTop: "calc(var(--app-header-offset,64px) + 4rem)" }} className="scroll-mt-24 md:scroll-mt-28" />
 
@@ -3070,6 +3487,8 @@ export default function RipStatisticsPageClient({
                   )}
                 </div>
               </section>
+            ) : null}
+              </>
             ) : null}
           </>
         ) : null}

--- a/frontend/components/explore/RipStatisticsPageClient.jsx
+++ b/frontend/components/explore/RipStatisticsPageClient.jsx
@@ -15,6 +15,7 @@ import { RANK_CONFIG } from "@/constants/rankConfig";
 import { getFriendlyMetricLabel, getScoreTootip, getFormattedTooltip, getMetricTooltip } from "@/constants/interpretabilityConfig";
 import { getCalloutAccentStyle, getDangerValueStyle, getInterpretationTone } from "@/lib/explore/interpretationTone";
 import { getPokemonSetCards } from "@/lib/pokemon/pokemonSetCardsClient";
+import { normalizeHistoryTrendPoint } from "./packValueHistoryNormalization.mjs";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
   style: "currency",
@@ -101,6 +102,72 @@ const SIMPLE_PILLAR_INFO_COPY = {
     "Safety explains how painful the misses can feel. A set can have a strong overall score but still feel risky if the lower-end packs give back very little value.",
   Stability:
     "Stability explains whether value is spread across the set or concentrated in only a few cards. Better stability means the set is less dependent on one or two major hits.",
+};
+
+const METRIC_TREND_DIRECTIONS = {
+  ripScore: "higher",
+  packScore: "higher",
+  profitScore: "higher",
+  safetyScore: "higher",
+  stabilityScore: "higher",
+  packCost: "neutral",
+  setValue: "higher",
+  simulatedSetValue: "higher",
+  averagePackValue: "higher",
+  meanValue: "higher",
+  averageHitValue: "higher",
+  chanceToBeatPackCost: "higher",
+  probProfit: "higher",
+  chanceToMissPackCost: "lower",
+  chanceAtBigPull: "higher",
+  probBigHit: "higher",
+  averageReturnVsCost: "higher",
+  meanValueToCostRatio: "higher",
+  typicalReturnVsCost: "higher",
+  medianValueToCostRatio: "higher",
+  bigHitUpside: "higher",
+  p95ValueToCostRatio: "higher",
+  godPullUpside: "higher",
+  p99ValueToCostRatio: "higher",
+  chaseDepth: "higher",
+  effectiveChaseCount: "higher",
+  averageLoss: "lower",
+  expectedLossPerPack: "lower",
+  averageLossWhenYouMiss: "lower",
+  expectedLossWhenLosing: "lower",
+  typicalLossWhenYouMiss: "lower",
+  medianLossWhenLosing: "lower",
+  p05ShortfallToCost: "lower",
+  outcomeVolatility: "lower",
+  coefficientOfVariation: "lower",
+  evConcentration: "lower",
+  hhiEvConcentration: "lower",
+  top1Share: "neutral",
+  top3Share: "neutral",
+  top5Share: "neutral",
+};
+
+const HISTORY_METRIC_ALIASES = {
+  ripScore: ["relative_pack_score", "relativePackScore", "pack_score", "packScore"],
+  profitScore: ["relative_profit_score", "relativeProfitScore", "profit_score", "profitScore"],
+  safetyScore: ["relative_safety_score", "relativeSafetyScore", "safety_score", "safetyScore"],
+  stabilityScore: ["relative_stability_score", "relativeStabilityScore", "stability_score", "stabilityScore"],
+  setValue: ["simulated_set_value", "simulatedSetValue", "set_value", "setValue"],
+  averageHitValue: ["average_hit_value", "averageHitValue"],
+  probProfit: ["prob_profit", "probProfit", "chance_to_beat_pack_cost", "chanceToBeatPackCost"],
+  probBigHit: ["prob_big_hit", "probBigHit", "chance_at_big_pull", "chanceAtBigPull"],
+  p99ValueToCostRatio: ["p99_value_to_cost_ratio", "p99ValueToCostRatio", "god_pull_upside", "godPullUpside"],
+  expectedLossWhenLosing: ["expected_loss_when_losing", "expectedLossWhenLosing"],
+  medianLossWhenLosing: ["median_loss_when_losing", "medianLossWhenLosing"],
+  tailValueP05: ["tail_value_p05", "tailValueP05", "p05_value", "p05Value", "bad_pack_floor_value", "badPackFloorValue"],
+  p05ShortfallToCost: ["p05_shortfall_to_cost", "p05ShortfallToCost", "worst_5_percent_shortfall", "worst5PercentShortfall"],
+  coefficientOfVariation: ["coefficient_of_variation", "coefficientOfVariation"],
+  hhiEvConcentration: ["hhi_ev_concentration", "hhiEvConcentration", "ev_concentration", "evConcentration"],
+  effectiveChaseCount: ["effective_chase_count", "effectiveChaseCount", "chase_depth", "chaseDepth"],
+  top1Share: ["top1_ev_share", "top1EvShare", "top_chase_share", "topChaseShare"],
+  top3Share: ["top3_ev_share", "top3EvShare"],
+  top5Share: ["top5_ev_share", "top5EvShare"],
+  maxValue: ["max_value", "maxValue", "best_pull", "bestPull"],
 };
 
 function toNumber(value) {
@@ -205,13 +272,13 @@ function ChecklistCardTile({ card }) {
   const marketPrice = Number.isFinite(card?.marketPrice) ? currencyFormatter.format(card.marketPrice) : null;
 
   return (
-    <article className="overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-page)]/55 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.02),0_8px_18px_rgba(2,6,23,0.14)]">
-      <div className="relative aspect-[3/4] w-full border-b border-[var(--border-subtle)] bg-[var(--surface-panel)]/80">
+    <article className="group overflow-hidden rounded-xl border border-[rgba(255,255,255,0.08)] bg-[rgba(15,23,42,0.72)] shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_10px_26px_rgba(2,6,23,0.2)] transition-all duration-200 hover:-translate-y-1 hover:border-[rgba(94,234,212,0.22)] hover:bg-[rgba(15,23,42,0.86)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_18px_34px_rgba(2,6,23,0.3)]">
+      <div className="relative aspect-[3/4] w-full border-b border-[rgba(255,255,255,0.07)] bg-[rgba(2,6,23,0.46)]">
         {imageUrl ? (
           <img
             src={imageUrl}
             alt={name}
-            className="h-full w-full object-cover"
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.015]"
             loading="lazy"
             decoding="async"
           />
@@ -268,10 +335,69 @@ function normalizePullRateAssumptions(explorePayload) {
   };
 }
 
-function SectionViewTabs({ value, onChange, options, className = "" }) {
+function SectionViewTabs({ value, onChange, options, className = "", variant = "default" }) {
   const tabOptions = Array.isArray(options) ? options : [];
   if (tabOptions.length === 0) {
     return null;
+  }
+
+  if (variant === "primary") {
+    return (
+      <div className={className}>
+        <div
+          className="grid w-full items-center gap-0.5 rounded-lg border border-[rgba(255,255,255,0.08)] bg-[rgba(2,6,23,0.72)] p-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_8px_20px_rgba(2,6,23,0.18)] backdrop-blur-md"
+          style={{ gridTemplateColumns: `repeat(${tabOptions.length}, minmax(0, 1fr))` }}
+        >
+          {tabOptions.map((option) => {
+            const isActive = value === option.value;
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => onChange(option.value)}
+                aria-pressed={isActive}
+                className={`min-w-0 rounded-md px-2 py-1 text-xs font-semibold leading-none transition-all duration-200 sm:px-3 sm:py-1.5 ${
+                  isActive
+                    ? "bg-[linear-gradient(135deg,rgba(16,185,129,0.95),rgba(20,184,166,0.78))] text-white shadow-[0_4px_12px_rgba(20,184,166,0.18),inset_0_1px_0_rgba(255,255,255,0.16)]"
+                    : "bg-transparent text-[color:color-mix(in_srgb,var(--text-secondary)_82%,transparent)] hover:bg-[rgba(255,255,255,0.045)] hover:text-[var(--text-primary)]"
+                }`}
+              >
+                <span className="block truncate">{option.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  if (variant === "secondary") {
+    return (
+      <div className={className}>
+        <div className="inline-flex max-w-full items-center gap-1 rounded-full border border-[rgba(255,255,255,0.08)] bg-[rgba(15,23,42,0.58)] p-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+          {tabOptions.map((option) => {
+            const isActive = value === option.value;
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => onChange(option.value)}
+                aria-pressed={isActive}
+                className={`min-w-0 rounded-full px-3 py-1.5 text-[11px] font-semibold leading-none transition-all duration-200 sm:px-4 sm:text-xs ${
+                  isActive
+                    ? "bg-[rgba(20,184,166,0.16)] text-[var(--accent)] shadow-[inset_0_0_0_1px_rgba(94,234,212,0.2)]"
+                    : "text-[var(--text-secondary)] hover:bg-[rgba(255,255,255,0.045)] hover:text-[var(--text-primary)]"
+                }`}
+              >
+                <span className="block truncate">{option.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -314,6 +440,135 @@ function getSimpleAverageLossValue(summary) {
 
   const expectedLossPerPack = toNumber(summary?.expected_loss_per_pack);
   return expectedLossPerPack === null ? null : -Math.abs(expectedLossPerPack);
+}
+
+function getLossAmountFromMeanAndCost(meanValue, packCost) {
+  const mean = toNumber(meanValue);
+  const cost = toNumber(packCost);
+  if (mean === null || cost === null) {
+    return null;
+  }
+  return Math.max(cost - mean, 0);
+}
+
+function getHistoryMetricValue(point, metricKey) {
+  if (!point) {
+    return null;
+  }
+
+  const rawPoint = point.rawPoint || {};
+  const directValue = toNumber(point[metricKey]);
+  if (directValue !== null) {
+    return directValue;
+  }
+
+  switch (metricKey) {
+    case "packCost":
+      return toNumber(point.packCost) ?? getFirstNumericValue(rawPoint, ["pack_cost", "packCost", "cost"]);
+    case "meanValue":
+      return toNumber(point.meanValue) ?? getFirstNumericValue(rawPoint, ["mean_value", "meanValue", "average_pack_value", "averagePackValue"]);
+    case "medianValue":
+      return toNumber(point.medianValue) ?? getFirstNumericValue(rawPoint, ["median_value", "medianValue", "typical_pack_value", "typicalPackValue"]);
+    case "meanCostRatio":
+      return toNumber(point.meanCostRatio) ?? getFirstNumericValue(rawPoint, ["mean_value_to_cost_ratio", "meanValueToCostRatio", "average_return_vs_cost", "averageReturnVsCost"]);
+    case "medianCostRatio":
+      return toNumber(point.medianCostRatio) ?? getFirstNumericValue(rawPoint, ["median_value_to_cost_ratio", "medianValueToCostRatio", "typical_return_vs_cost", "typicalReturnVsCost"]);
+    case "p95CostRatio":
+      return toNumber(point.p95CostRatio) ?? getFirstNumericValue(rawPoint, ["p95_value_to_cost_ratio", "p95ValueToCostRatio", "big_hit_upside", "bigHitUpside"]);
+    default:
+      return getFirstNumericValue(rawPoint, HISTORY_METRIC_ALIASES[metricKey] || []);
+  }
+}
+
+function getMetricDirection(metricKey, fallbackDirection = "higher") {
+  return METRIC_TREND_DIRECTIONS[metricKey] || fallbackDirection;
+}
+
+function getMetricTrend({ currentValue, previousValue, direction = "higher", metricKey = null } = {}) {
+  const current = toNumber(currentValue);
+  const previous = toNumber(previousValue);
+  const resolvedDirection = metricKey ? getMetricDirection(metricKey, direction) : direction;
+
+  if (current === null || previous === null) {
+    return { trend: "unknown", isImprovement: null };
+  }
+
+  const delta = current - previous;
+  if (Math.abs(delta) < 0.000001) {
+    return { trend: "flat", isImprovement: null };
+  }
+
+  const trend = delta > 0 ? "up" : "down";
+  if (resolvedDirection === "neutral") {
+    return { trend, isImprovement: null };
+  }
+
+  const isImprovement = resolvedDirection === "lower" ? delta < 0 : delta > 0;
+  return { trend, isImprovement };
+}
+
+function getHistoryMetricTrend({ metricKey, currentValue, previousPoint, previousValue = null, direction = "higher" }) {
+  return getMetricTrend({
+    currentValue,
+    previousValue: previousValue ?? getHistoryMetricValue(previousPoint, metricKey),
+    direction,
+    metricKey,
+  });
+}
+
+function TrendIndicator({ trend, className = "" }) {
+  if (!trend || trend.trend === "unknown") {
+    return null;
+  }
+
+  const isFlat = trend.trend === "flat";
+  const iconClassName = isFlat ? "h-4 w-4" : "h-6 w-6";
+  const wrapperClassName = isFlat ? "h-5 w-5" : "h-7 w-7";
+  const displayTrend =
+    trend.isImprovement === true
+      ? "up"
+      : trend.isImprovement === false
+      ? "down"
+      : "flat";
+  const color =
+    trend.isImprovement === true
+      ? "var(--success,#10B981)"
+      : trend.isImprovement === false
+      ? "var(--danger,#EF4444)"
+      : "var(--text-secondary)";
+  const label =
+    trend.isImprovement === true
+      ? "Improved from previous snapshot"
+      : trend.isImprovement === false
+      ? "Worsened from previous snapshot"
+      : isFlat
+      ? "Unchanged from previous snapshot"
+      : "Neutral trend from previous snapshot";
+
+  return (
+    <span
+      className={["inline-flex flex-none items-center justify-center", wrapperClassName, className].filter(Boolean).join(" ")}
+      style={{ color }}
+      title={label}
+      aria-label={label}
+    >
+      <svg viewBox="0 0 20 20" aria-hidden="true" className={iconClassName}>
+        {displayTrend === "flat" ? (
+          <path d="M4.5 10h11" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" />
+        ) : displayTrend === "up" ? (
+          <>
+            <path d="M4.4 13.1 8.1 9.4l2.6 2.5 4.9-5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M12.1 6.9h3.5v3.5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+          </>
+        ) : (
+          <>
+            <path d="M4.4 6.9 8.1 10.6l2.6-2.5 4.9 5" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+            <path d="M12.1 13.1h3.5V9.6" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+          </>
+        )}
+      </svg>
+    </span>
+  );
 }
 
 function titleCaseStateLabel(value) {
@@ -462,7 +717,7 @@ function HorizontalBar({ widthPercent, nonzeroMin = 2 }) {
   );
 }
 
-function MetricRow({ label, value, infoText }) {
+function MetricRow({ label, value, infoText, trend = null }) {
   const friendlyLabel = getFriendlyMetricLabel(label);
   const isNegativeValue = typeof value === "string" && value.trim().startsWith("-");
   return (
@@ -471,16 +726,19 @@ function MetricRow({ label, value, infoText }) {
         <span className="text-sm text-[var(--text-secondary)]">{friendlyLabel}</span>
         {infoText ? <InfoPopover text={infoText} /> : null}
       </div>
-      <span className="text-sm font-medium" style={isNegativeValue ? getDangerValueStyle() : undefined}>{value}</span>
+      <span className="inline-flex flex-none items-center gap-1.5 text-sm font-medium" style={isNegativeValue ? getDangerValueStyle() : undefined}>
+        <TrendIndicator trend={trend} />
+        <span>{value}</span>
+      </span>
     </div>
   );
 }
 
-function HeroMetricTile({ label, value }) {
+function HeroMetricTile({ label, value, trend = null }) {
   const friendlyLabel = getFriendlyMetricLabel(label);
   const infoText =
     label === RIP_COPY.simpleMetrics.averageHitValue
-      ? "Average value of packs that contain a meaningful hit, excluding normal low-value outcomes."
+      ? "Average market value of pulled hit cards in the simulation. Pattern overlays are excluded."
       : getMetricTooltip(label);
   const isNegativeValue = typeof value === "string" && value.trim().startsWith("-");
   return (
@@ -489,9 +747,10 @@ function HeroMetricTile({ label, value }) {
         <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[color:color-mix(in_srgb,var(--text-primary)_72%,var(--text-secondary))]">{friendlyLabel}</p>
         {infoText ? <InfoPopover text={infoText} /> : null}
       </div>
-      <p className="mt-2 text-lg font-bold leading-tight [text-shadow:0_1px_1px_rgba(2,6,23,0.22)]" style={isNegativeValue ? getDangerValueStyle() : { color: "var(--text-primary)" }}>
-        {value}
-      </p>
+      <div className="mt-2 inline-flex items-center gap-1.5 text-lg font-bold leading-tight [text-shadow:0_1px_1px_rgba(2,6,23,0.22)]" style={isNegativeValue ? getDangerValueStyle() : { color: "var(--text-primary)" }}>
+        <span>{value}</span>
+        <TrendIndicator trend={trend} className="translate-y-px" />
+      </div>
     </div>
   );
 }
@@ -642,7 +901,7 @@ function RecommendationBadge({ label, rankTier }) {
     return null;
   }
 
-  return <InterpretationBadge label={label} rankTier={rankTier} className="px-2.5 py-0.5 text-[10px] tracking-[0.08em]" />;
+  return <InterpretationBadge label={label} rankTier={rankTier} className="px-3 py-1 text-[12px] tracking-[0.08em]" />;
 }
 
 function MobileMetricAccordion({
@@ -1184,6 +1443,7 @@ function SetIntelligenceSection({ summary, simpleMode = false, setIntelligenceMe
 function ScorePillarCard({
   title,
   score,
+  scoreTrend = null,
   rankValue,
   rankTier,
   simpleMetrics,
@@ -1204,7 +1464,10 @@ function ScorePillarCard({
         <div className="min-w-0">
           <div className="flex min-w-0 flex-wrap items-center gap-2.5">
             <h3 className="text-base font-semibold tracking-[0.01em] text-[var(--text-secondary)]">{title}</h3>
-            <p className="text-2xl font-bold leading-none text-[var(--text-primary)]">{formatScore(score)}</p>
+            <p className="inline-flex items-center gap-1.5 text-2xl font-bold leading-none text-[var(--text-primary)]">
+              <span>{formatScore(score)}</span>
+              <TrendIndicator trend={scoreTrend} className="translate-y-0.5" />
+            </p>
             <RankBadge rank={rankTier} label={rankLabel} title={numericRankTitle} size="supporting" subtle />
           </div>
         </div>
@@ -1240,7 +1503,8 @@ function ScorePillarCard({
               key={metric.label}
               label={metric.label}
               value={metric.value}
-              infoText={getMetricTooltip(metric.label)}
+              trend={metric.trend}
+              infoText={metric.infoText || getMetricTooltip(metric.label)}
             />
           ))}
         </div>
@@ -1260,7 +1524,8 @@ function ScorePillarCard({
               key={`mobile-${title}-${metric.label}`}
               label={metric.label}
               value={metric.value}
-              infoText={getMetricTooltip(metric.label)}
+              trend={metric.trend}
+              infoText={metric.infoText || getMetricTooltip(metric.label)}
             />
           ))}
         </div>
@@ -1323,7 +1588,7 @@ function SimplePillarSummaryCard({
   );
 }
 
-function StatTile({ label, value, valueClassName = "text-lg", infoText = null }) {
+function StatTile({ label, value, valueClassName = "text-lg", infoText = null, trend = null }) {
   return (
     <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-page)]/60 p-4">
       <div className="flex min-w-0 items-start justify-between gap-2">
@@ -1336,7 +1601,10 @@ function StatTile({ label, value, valueClassName = "text-lg", infoText = null })
           </span>
         ) : null}
       </div>
-      <p className={`mt-2 font-semibold text-[var(--text-primary)] ${valueClassName}`}>{value}</p>
+      <p className={`mt-2 inline-flex items-center gap-1.5 font-semibold text-[var(--text-primary)] ${valueClassName}`}>
+        <span>{value}</span>
+        <TrendIndicator trend={trend} className="translate-y-px" />
+      </p>
     </div>
   );
 }
@@ -1695,6 +1963,148 @@ function SectionNavigation({ items, activeSection, onSelect, mobile = false }) {
         );
       })}
     </nav>
+  );
+}
+
+function SetPageRailButton({ label, active, onClick, level = "primary" }) {
+  const isSubLink = level === "sub";
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-current={active ? "location" : undefined}
+      className={[
+        "group flex w-full items-center justify-between rounded-lg border text-left transition-colors",
+        isSubLink ? "px-2.5 py-1.5 text-xs" : "px-3 py-2 text-sm font-medium",
+        active
+          ? "border-[rgba(94,234,212,0.26)] bg-[color:color-mix(in_srgb,var(--accent)_10%,transparent)] text-[var(--text-primary)]"
+          : "border-transparent text-[var(--text-secondary)] hover:border-[var(--border-subtle)] hover:bg-[var(--surface-page)]/70 hover:text-[var(--text-primary)]",
+      ].join(" ")}
+    >
+      <span className="flex min-w-0 items-center gap-2">
+        <span
+          aria-hidden="true"
+          className={[
+            "rounded-full transition-colors",
+            isSubLink ? "h-1.5 w-1.5" : "h-2 w-2",
+            active ? "bg-[var(--accent)]" : "bg-[var(--border-subtle)] group-hover:bg-[var(--text-secondary)]",
+          ].join(" ")}
+        />
+        <span className="min-w-0 truncate">{label}</span>
+      </span>
+    </button>
+  );
+}
+
+function SetPageNavigationRail({
+  targets,
+  requestedTargetId,
+  selectedTarget,
+  selectedName,
+  isPending,
+  activeTab,
+  activeCardsSubTab,
+  activeGraphMode,
+  onTargetChange,
+  onNavigate,
+}) {
+  const topSections = [
+    { id: "cards", label: "Cards" },
+    { id: "pull-rates", label: "Pull Rates" },
+    { id: "analytics", label: "Analytics" },
+  ];
+
+  const visibleSubLinks =
+    activeTab === "cards"
+      ? [
+          { id: "checklist", label: "Checklist", tab: "cards", cardsSubTab: "checklist", active: activeCardsSubTab === "checklist" },
+          { id: "simulated-impact", label: "Simulated Impact", tab: "cards", cardsSubTab: "simulated-impact", active: activeCardsSubTab === "simulated-impact" },
+        ]
+      : activeTab === "pull-rates"
+      ? [
+          { id: "pull-rate-assumptions", label: "Pull Rate Assumptions", tab: "pull-rates", active: true },
+        ]
+      : [
+          { id: "pillars", label: "Profit / Safety / Stability", tab: "analytics", targetId: "set-detail-analytics", active: activeGraphMode === "outcome-distribution" },
+          { id: "value-drivers", label: "Value Drivers", tab: "analytics", targetId: "set-detail-analytics", active: false },
+          { id: "rarity-contribution", label: "Rarity Contribution", tab: "analytics", graphMode: "value-contribution", targetId: ANALYSIS_SECTION_ID, active: activeGraphMode === "value-contribution" },
+          { id: "historical-trend", label: "Historical Trend", tab: "analytics", graphMode: "historical-trend", targetId: ANALYSIS_SECTION_ID, active: activeGraphMode === "historical-trend" },
+          { id: "pack-breakdown", label: "Pack Breakdown", tab: "analytics", graphMode: "pack-breakdown", targetId: ANALYSIS_SECTION_ID, active: activeGraphMode === "pack-breakdown" },
+        ];
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-[var(--border-subtle)] bg-[color:color-mix(in_srgb,var(--surface-page)_78%,transparent)] p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_12px_30px_rgba(2,6,23,0.18)] backdrop-blur-md">
+      <div className="space-y-2">
+        <p className="px-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-secondary)]">
+          Set Control
+        </p>
+        <label htmlFor="set-page-rail-target" className="sr-only">
+          Switch set
+        </label>
+        <select
+          id="set-page-rail-target"
+          value={requestedTargetId || ""}
+          onChange={onTargetChange}
+          disabled={isPending || targets.length === 0}
+          title={targets.length > 0 ? "Switch set" : "No sets available"}
+          className="w-full rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-page)] px-2.5 py-2 text-sm font-medium text-[var(--text-primary)] outline-none transition-colors focus:border-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          {targets.map((target) => (
+            <option key={`rail-set:${target.target_type}:${target.target_id}`} value={target.target_id}>
+              {target.name}
+            </option>
+          ))}
+        </select>
+        {selectedTarget?.era ? (
+          <div className="flex items-center gap-2 px-1">
+            <span className="text-[11px] font-medium text-[var(--text-secondary)]">Era</span>
+            <span className="inline-flex min-w-0 max-w-full items-center rounded-full border border-[var(--border-subtle)] bg-[var(--surface-page)] px-2 py-0.5 text-[11px] text-[var(--text-secondary)]">
+              <span className="truncate">{selectedTarget.era}</span>
+            </span>
+          </div>
+        ) : (
+          <p className="px-1 text-[11px] text-[var(--text-secondary)]">{selectedName}</p>
+        )}
+      </div>
+
+      <div className="h-px w-full bg-[var(--border-subtle)]" />
+
+      <nav aria-label="Set page navigation" className="space-y-3">
+        <div>
+          <p className="px-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-secondary)]">
+            Sections
+          </p>
+          <div className="mt-2 space-y-1">
+            {topSections.map((section) => (
+              <SetPageRailButton
+                key={section.id}
+                label={section.label}
+                active={activeTab === section.id}
+                onClick={() => onNavigate({ tab: section.id })}
+              />
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <p className="px-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-secondary)]">
+            In This View
+          </p>
+          <div className="mt-2 space-y-1">
+            {visibleSubLinks.map((link) => (
+              <SetPageRailButton
+                key={link.id}
+                label={link.label}
+                level="sub"
+                active={link.active}
+                onClick={() => onNavigate(link)}
+              />
+            ))}
+          </div>
+        </div>
+      </nav>
+    </div>
   );
 }
 
@@ -2162,6 +2572,23 @@ export default function RipStatisticsPageClient({
     window.scrollTo({ top: Math.max(0, targetTop), behavior: "smooth" });
   };
 
+  const scrollToSetDetailElement = (targetId = "set-detail-content") => {
+    if (typeof document === "undefined" || typeof window === "undefined") {
+      return;
+    }
+
+    window.requestAnimationFrame(() => {
+      const target = getVisibleSectionElement(targetId);
+      if (!target) {
+        return;
+      }
+
+      const stickyOffset = getExploreStickyOffset();
+      const targetTop = target.getBoundingClientRect().top + window.scrollY - stickyOffset;
+      window.scrollTo({ top: Math.max(0, targetTop), behavior: "smooth" });
+    });
+  };
+
   const handleSectionSelect = (sectionId) => {
     pendingNavSelectionRef.current = sectionId;
     pendingNavStartedAtRef.current = Date.now();
@@ -2188,6 +2615,32 @@ export default function RipStatisticsPageClient({
 
     setActiveSection(sectionId);
     scrollToExploreSection(sectionId);
+  };
+
+  const handleSetDetailNavSelect = ({ tab, cardsSubTab: nextCardsSubTab, graphMode: nextGraphMode, targetId } = {}) => {
+    const nextTab = tab || setDetailTab;
+
+    if (nextTab) {
+      setSetDetailTab(nextTab);
+    }
+
+    if (nextCardsSubTab) {
+      setCardsSubTab(nextCardsSubTab);
+    }
+
+    if (nextGraphMode) {
+      setGraphMode(nextGraphMode);
+      setActiveSection(nextGraphMode);
+    }
+
+    const fallbackTargetId =
+      nextTab === "cards"
+        ? "set-detail-cards"
+        : nextTab === "pull-rates"
+        ? "set-detail-pull-rates"
+        : "set-detail-analytics";
+
+    scrollToSetDetailElement(targetId || fallbackTargetId);
   };
 
   useEffect(() => {
@@ -2310,6 +2763,7 @@ export default function RipStatisticsPageClient({
   const simpleAverageLossValue = getSimpleAverageLossValue(summary);
   const averageHitValue = getFirstNumericValue(summary, [
     "average_hit_value",
+    "average_hit_value_when_hit",
     "hit_average_value",
     "average_value_when_hit",
     "big_pull_average",
@@ -2318,6 +2772,7 @@ export default function RipStatisticsPageClient({
     "average_pack_value_of_hits",
   ]);
   const setValue = getFirstNumericValue(summary, [
+    "simulated_set_value",
     "set_value",
     "total_set_value",
     "total_card_value",
@@ -2328,14 +2783,172 @@ export default function RipStatisticsPageClient({
 
   const averageHitValueDisplay = averageHitValue === null ? "Coming soon" : formatCurrency(averageHitValue);
   const setValueDisplay = setValue === null ? "Coming soon" : formatCurrency(setValue);
+  const normalizedHistoryTrendPoints = Array.isArray(historyTrend)
+    ? historyTrend.map((row, index) => normalizeHistoryTrendPoint(row, index, null))
+    : [];
+  const previousTrendPoint =
+    normalizedHistoryTrendPoints.length >= 2
+      ? normalizedHistoryTrendPoints[normalizedHistoryTrendPoints.length - 2]
+      : null;
+  const currentAverageLossAmount = getLossAmountFromMeanAndCost(summary.mean_value, summary.pack_cost);
+  const previousAverageLossAmount = getLossAmountFromMeanAndCost(
+    previousTrendPoint?.meanValue,
+    previousTrendPoint?.packCost
+  );
+  const trendByMetricKey = {
+    ripScore: getHistoryMetricTrend({
+      metricKey: "ripScore",
+      currentValue: topScoreRaw,
+      previousPoint: previousTrendPoint,
+    }),
+    profitScore: getHistoryMetricTrend({
+      metricKey: "profitScore",
+      currentValue: displayedProfitScore,
+      previousPoint: previousTrendPoint,
+    }),
+    safetyScore: getHistoryMetricTrend({
+      metricKey: "safetyScore",
+      currentValue: displayedSafetyScore,
+      previousPoint: previousTrendPoint,
+    }),
+    stabilityScore: getHistoryMetricTrend({
+      metricKey: "stabilityScore",
+      currentValue: displayedStabilityScore,
+      previousPoint: previousTrendPoint,
+    }),
+    packCost: getHistoryMetricTrend({
+      metricKey: "packCost",
+      currentValue: summary.pack_cost,
+      previousPoint: previousTrendPoint,
+    }),
+    setValue: getHistoryMetricTrend({
+      metricKey: "setValue",
+      currentValue: setValue,
+      previousPoint: previousTrendPoint,
+    }),
+    averagePackValue: getHistoryMetricTrend({
+      metricKey: "meanValue",
+      currentValue: summary.mean_value,
+      previousPoint: previousTrendPoint,
+    }),
+    averageHitValue: getHistoryMetricTrend({
+      metricKey: "averageHitValue",
+      currentValue: averageHitValue,
+      previousPoint: previousTrendPoint,
+    }),
+    averageLoss: getMetricTrend({
+      currentValue: currentAverageLossAmount,
+      previousValue: previousAverageLossAmount,
+      metricKey: "averageLoss",
+    }),
+    chanceToBeatPackCost: getHistoryMetricTrend({
+      metricKey: "probProfit",
+      currentValue: normalizeProbability(summary.prob_profit),
+      previousPoint: previousTrendPoint,
+    }),
+    chanceToMissPackCost: getHistoryMetricTrend({
+      metricKey: "chanceToMissPackCost",
+      currentValue: normalizeProbability(summary.prob_profit) === null ? null : 1 - normalizeProbability(summary.prob_profit),
+      previousValue:
+        getHistoryMetricValue(previousTrendPoint, "probProfit") === null
+          ? null
+          : 1 - normalizeProbability(getHistoryMetricValue(previousTrendPoint, "probProfit")),
+      direction: "lower",
+    }),
+    chanceAtBigPull: getHistoryMetricTrend({
+      metricKey: "probBigHit",
+      currentValue: normalizeProbability(summary.prob_big_hit),
+      previousPoint: previousTrendPoint,
+    }),
+    averageReturnVsCost: getHistoryMetricTrend({
+      metricKey: "meanCostRatio",
+      currentValue: meanValueToCostRatio,
+      previousPoint: previousTrendPoint,
+    }),
+    typicalReturnVsCost: getHistoryMetricTrend({
+      metricKey: "medianCostRatio",
+      currentValue: medianValueToCostRatio,
+      previousPoint: previousTrendPoint,
+    }),
+    bigHitUpside: getHistoryMetricTrend({
+      metricKey: "p95CostRatio",
+      currentValue: summary.p95_value_to_cost_ratio,
+      previousPoint: previousTrendPoint,
+    }),
+    godPullUpside: getHistoryMetricTrend({
+      metricKey: "p99ValueToCostRatio",
+      currentValue: summary.p99_value_to_cost_ratio,
+      previousPoint: previousTrendPoint,
+    }),
+    typicalPackValue: getHistoryMetricTrend({
+      metricKey: "medianValue",
+      currentValue: percentileP50 ?? summary.median_value,
+      previousPoint: previousTrendPoint,
+    }),
+    badPackFloorValue: getHistoryMetricTrend({
+      metricKey: "tailValueP05",
+      currentValue: percentileP5 ?? summary.tail_value_p05,
+      previousPoint: previousTrendPoint,
+    }),
+    averageLossWhenYouMiss: getHistoryMetricTrend({
+      metricKey: "expectedLossWhenLosing",
+      currentValue: summary.expected_loss_when_losing,
+      previousPoint: previousTrendPoint,
+    }),
+    typicalLossWhenYouMiss: getHistoryMetricTrend({
+      metricKey: "medianLossWhenLosing",
+      currentValue: summary.median_loss_when_losing,
+      previousPoint: previousTrendPoint,
+    }),
+    worstFivePercentShortfall: getHistoryMetricTrend({
+      metricKey: "p05ShortfallToCost",
+      currentValue: p05ShortfallToCost,
+      previousPoint: previousTrendPoint,
+    }),
+    outcomeVolatility: getHistoryMetricTrend({
+      metricKey: "coefficientOfVariation",
+      currentValue: summary.coefficient_of_variation,
+      previousPoint: previousTrendPoint,
+    }),
+    evConcentration: getHistoryMetricTrend({
+      metricKey: "hhiEvConcentration",
+      currentValue: summary.hhi_ev_concentration,
+      previousPoint: previousTrendPoint,
+    }),
+    chaseDepth: getHistoryMetricTrend({
+      metricKey: "effectiveChaseCount",
+      currentValue: summary.effective_chase_count,
+      previousPoint: previousTrendPoint,
+    }),
+    top1Share: getHistoryMetricTrend({
+      metricKey: "top1Share",
+      currentValue: summary.top1_ev_share,
+      previousPoint: previousTrendPoint,
+    }),
+    top3Share: getHistoryMetricTrend({
+      metricKey: "top3Share",
+      currentValue: summary.top3_ev_share,
+      previousPoint: previousTrendPoint,
+    }),
+    top5Share: getHistoryMetricTrend({
+      metricKey: "top5Share",
+      currentValue: summary.top5_ev_share,
+      previousPoint: previousTrendPoint,
+    }),
+    bestPull: getHistoryMetricTrend({
+      metricKey: "maxValue",
+      currentValue: summary.max_value,
+      previousPoint: previousTrendPoint,
+    }),
+  };
 
   const decisionMetrics = [
-    { label: RIP_COPY.simpleMetrics.currentPackCost, value: formatCurrency(summary.pack_cost) },
-    { label: RIP_COPY.simpleMetrics.averagePackValue, value: formatCurrency(summary.mean_value) },
-    { label: RIP_COPY.simpleMetrics.averageHitValue, value: averageHitValueDisplay },
-    { label: RIP_COPY.simpleMetrics.averageLoss, value: formatSignedCurrency(simpleAverageLossValue) },
-    { label: RIP_COPY.simpleMetrics.chanceToBeatPackCost, value: formatPercent(summary.prob_profit, { probability: true }) },
-    { label: RIP_COPY.simpleMetrics.chanceAtBigPull, value: formatPercent(summary.prob_big_hit, { probability: true }) },
+    { label: RIP_COPY.simpleMetrics.currentPackCost, value: formatCurrency(summary.pack_cost), trend: trendByMetricKey.packCost },
+    { label: RIP_COPY.simpleMetrics.averagePackValue, value: formatCurrency(summary.mean_value), trend: trendByMetricKey.averagePackValue },
+    { label: RIP_COPY.simpleMetrics.averageHitValue, value: averageHitValueDisplay, trend: trendByMetricKey.averageHitValue },
+    { label: RIP_COPY.simpleMetrics.averageLoss, value: formatSignedCurrency(simpleAverageLossValue), trend: trendByMetricKey.averageLoss },
+    { label: RIP_COPY.simpleMetrics.chanceToBeatPackCost, value: formatPercent(summary.prob_profit, { probability: true }), trend: trendByMetricKey.chanceToBeatPackCost },
+    { label: RIP_COPY.simpleMetrics.chanceAtBigPull, value: formatPercent(summary.prob_big_hit, { probability: true }), trend: trendByMetricKey.chanceAtBigPull },
   ];
   const primaryDecisionMetricOrder = [
     RIP_COPY.simpleMetrics.currentPackCost,
@@ -2350,13 +2963,13 @@ export default function RipStatisticsPageClient({
     (metric) => !primaryDecisionMetricOrder.includes(metric.label)
   );
   const technicalScoreMetrics = [
-    { label: "Average Return vs Cost", value: formatNumber(meanValueToCostRatio, 2) },
-    { label: "Typical Return vs Cost", value: formatNumber(medianValueToCostRatio, 2) },
-    { label: "Big Hit Upside", value: formatNumber(summary.p95_value_to_cost_ratio, 2) },
-    { label: "God Pull Upside", value: formatNumber(summary.p99_value_to_cost_ratio, 2) },
-    { label: "Outcome Volatility", value: formatNumber(summary.coefficient_of_variation, 2) },
-    { label: "Value Spread", value: formatNumber(summary.hhi_ev_concentration, 3) },
-    { label: "Cards Carrying Value", value: formatNumber(summary.effective_chase_count, 2) },
+    { label: "Average Return vs Cost", value: formatNumber(meanValueToCostRatio, 2), trend: trendByMetricKey.averageReturnVsCost },
+    { label: "Typical Return vs Cost", value: formatNumber(medianValueToCostRatio, 2), trend: trendByMetricKey.typicalReturnVsCost },
+    { label: "Big Hit Upside", value: formatNumber(summary.p95_value_to_cost_ratio, 2), trend: trendByMetricKey.bigHitUpside },
+    { label: "God Pull Upside", value: formatNumber(summary.p99_value_to_cost_ratio, 2), trend: trendByMetricKey.godPullUpside },
+    { label: "Outcome Volatility", value: formatNumber(summary.coefficient_of_variation, 2), trend: trendByMetricKey.outcomeVolatility },
+    { label: "Value Spread", value: formatNumber(summary.hhi_ev_concentration, 3), trend: trendByMetricKey.evConcentration },
+    { label: "Cards Carrying Value", value: formatNumber(summary.effective_chase_count, 2), trend: trendByMetricKey.chaseDepth },
   ];
 
   const handleTargetIdChange = (nextTargetId, options = {}) => {
@@ -2472,6 +3085,21 @@ export default function RipStatisticsPageClient({
       isCancelled = true;
     };
   }, [setDetailMode, setDetailTab, cardsSubTab, requestedTargetId]);
+
+  const setDetailSidebarContent = (
+    <SetPageNavigationRail
+      targets={targets}
+      requestedTargetId={requestedTargetId}
+      selectedTarget={selectedTarget}
+      selectedName={selectedName}
+      isPending={isPending}
+      activeTab={setDetailTab}
+      activeCardsSubTab={cardsSubTab}
+      activeGraphMode={graphMode}
+      onTargetChange={handleTargetChange}
+      onNavigate={handleSetDetailNavSelect}
+    />
+  );
 
   const desktopSidebarContent = (
     <div className="space-y-5 rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-page)]/72 p-4 backdrop-blur-sm">
@@ -2603,7 +3231,7 @@ export default function RipStatisticsPageClient({
         mode="public"
         sectionItems={[]}
         mobileNavItems={[]}
-        desktopSidebarContent={setDetailMode ? null : desktopSidebarContent}
+        desktopSidebarContent={setDetailMode ? setDetailSidebarContent : desktopSidebarContent}
         mobileToolsPanelContent={setDetailMode ? null : renderMobileToolsPanelContent}
         mobileToolsTitle="Explore Filters & Navigation"
         mobileToolsDescription="Switch TCG and set filters."
@@ -2612,7 +3240,8 @@ export default function RipStatisticsPageClient({
         mobileToolsTriggerTitle="Open filters and navigation"
         useFloatingToolsOnTablet={!setDetailMode}
         forceCompactToolsBelow2xl={!setDetailMode}
-        centerContentIgnoringSidebar
+        centerContentIgnoringSidebar={!setDetailMode}
+        desktopSidebarClassName={setDetailMode ? "xl:w-[244px] xl:min-w-[244px] xl:pl-4 xl:pr-3" : ""}
         desktopContentOffsetClassName="xl:flex xl:justify-center"
         wrapDesktopContentInFrame={false}
         mobileBottomNavVariant="flat"
@@ -2663,96 +3292,103 @@ export default function RipStatisticsPageClient({
                     <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.7fr)] lg:items-stretch">
                       <div className="flex h-full min-h-full flex-col gap-3">
                       <div ref={heroSetPickerRef} data-hero-picker className="relative z-20 rounded-xl border border-[var(--border-subtle)] bg-[color:color-mix(in_srgb,var(--surface-page)_78%,transparent)] p-4 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.03),0_8px_20px_rgba(2,6,23,0.12)] backdrop-blur-[2px]">
-                        <CenteredSuffixInline
-                          as="button"
-                          type="button"
-                          onClick={() => setHeroSetPickerOpen((open) => !open)}
-                          disabled={isPending || targets.length === 0}
-                          aria-expanded={heroSetPickerOpen}
-                          aria-haspopup="listbox"
-                          aria-controls="hero-set-picker-list"
-                          className="block w-full rounded-lg px-2 py-0 text-left text-xl font-semibold text-[var(--text-primary)] transition-colors hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] md:text-2xl disabled:cursor-not-allowed disabled:opacity-90"
-                          contentClassName="max-w-full whitespace-normal break-words leading-tight"
-                          suffixWrapperClassName="right-1"
-                          suffix={
-                            <svg
-                              aria-hidden="true"
-                              viewBox="0 0 20 20"
-                              className={`h-4 w-4 flex-none text-[var(--text-secondary)] transition-transform ${heroSetPickerOpen ? "rotate-180" : ""}`}
-                              fill="currentColor"
+                        <div className="space-y-4">
+                          <div>
+                            <button
+                              type="button"
+                              onClick={() => setHeroSetPickerOpen((open) => !open)}
+                              disabled={isPending || targets.length === 0}
+                              aria-expanded={heroSetPickerOpen}
+                              aria-haspopup="listbox"
+                              aria-controls="hero-set-picker-list"
+                              className="flex w-full min-w-0 items-start justify-between gap-3 rounded-lg text-left text-xl font-semibold text-[var(--text-primary)] transition-colors hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] md:text-2xl disabled:cursor-not-allowed disabled:opacity-90"
+                              title={targets.length > 0 ? "Switch set" : "No sets available"}
                             >
-                              <path d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.12l3.71-3.89a.75.75 0 1 1 1.08 1.04l-4.25 4.45a.75.75 0 0 1-1.08 0L5.21 8.27a.75.75 0 0 1 .02-1.06Z" />
-                            </svg>
-                          }
-                          title={targets.length > 0 ? "Switch set" : "No sets available"}
-                        >
-                          <span>{selectedName}</span>
-                        </CenteredSuffixInline>
-
-                        {heroSetPickerOpen ? (
-                          <div
-                            id="hero-set-picker-list"
-                            role="listbox"
-                            aria-label="Available sets"
-                            className="index-scrollbar absolute left-0 top-[calc(100%+0.5rem)] z-50 max-h-56 w-full max-w-full overflow-y-auto rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-panel)] p-1.5 text-left shadow-[0_14px_34px_rgba(0,0,0,0.45)]"
-                          >
-                            {targets.map((target) => {
-                              const isSelected = String(target.target_id) === String(requestedTargetId || "");
-                              return (
-                                <button
-                                  key={`hero-set-option:${target.target_type}:${target.target_id}`}
-                                  type="button"
-                                  role="option"
-                                  aria-selected={isSelected}
-                                  onClick={() => {
-                                    handleTargetIdChange(String(target.target_id || ""));
-                                    setHeroSetPickerOpen(false);
-                                  }}
-                                  className={`flex w-full items-center justify-between gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 transition-colors ${
-                                    isSelected
-                                      ? "bg-[var(--surface-page)] text-[var(--text-primary)]"
-                                      : "text-[var(--text-secondary)] hover:bg-[var(--surface-page)]/70 hover:text-[var(--text-primary)]"
-                                  }`}
+                              <span className="min-w-0 flex-1 whitespace-normal break-words leading-tight">{selectedName}</span>
+                              <span aria-hidden="true" className="mt-1 inline-flex h-6 w-6 flex-none items-center justify-center rounded-full border border-[var(--border-subtle)] bg-[var(--surface-page)]/70">
+                                <svg
+                                  aria-hidden="true"
+                                  viewBox="0 0 20 20"
+                                  className={`h-4 w-4 flex-none text-[var(--text-secondary)] transition-transform ${heroSetPickerOpen ? "rotate-180" : ""}`}
+                                  fill="currentColor"
                                 >
-                                  <span className="min-w-0 flex-1 truncate whitespace-nowrap">{target.name}</span>
-                                  {isSelected ? (
-                                    <span className="shrink-0 text-xs font-medium text-[var(--accent)]">Current</span>
-                                  ) : null}
-                                </button>
-                              );
-                            })}
-                          </div>
-                        ) : null}
+                                  <path d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.12l3.71-3.89a.75.75 0 1 1 1.08 1.04l-4.25 4.45a.75.75 0 0 1-1.08 0L5.21 8.27a.75.75 0 0 1 .02-1.06Z" />
+                                </svg>
+                              </span>
+                            </button>
 
-                        <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-secondary)]">{RIP_COPY.scoreLabel}</p>
-                        <div className="mt-2 flex items-end gap-2">
-                          <span className="text-5xl font-semibold leading-none tracking-[-0.04em] text-[var(--text-primary)] md:text-6xl">{displayedTopScore}</span>
-                          <span className="pb-1 text-xs font-medium text-[var(--text-secondary)]">/100</span>
-                        </div>
-                        <div className="mt-3">
-                          <ScoreMeter score={topScoreRaw} rankTier={summary.pack_tier} />
-                        </div>
-                        <div className="mt-3 flex items-center gap-2">
-                          <RankBadge
-                            rank={summary.pack_tier}
-                            label="Rank"
-                            size="md"
-                            title={
-                              summary.pack_rank === null || summary.pack_rank === undefined
-                                ? "Rank unavailable"
-                                : `Rank #${summary.pack_rank}`
-                            }
-                          />
-                          <RecommendationBadge label={recommendationBadge} rankTier={summary.pack_tier} />
+                            {heroSetPickerOpen ? (
+                              <div
+                                id="hero-set-picker-list"
+                                role="listbox"
+                                aria-label="Available sets"
+                                className="index-scrollbar absolute left-0 top-[calc(100%+0.5rem)] z-50 max-h-56 w-full max-w-full overflow-y-auto rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-panel)] p-1.5 text-left shadow-[0_14px_34px_rgba(0,0,0,0.45)]"
+                              >
+                                {targets.map((target) => {
+                                  const isSelected = String(target.target_id) === String(requestedTargetId || "");
+                                  return (
+                                    <button
+                                      key={`hero-set-option:${target.target_type}:${target.target_id}`}
+                                      type="button"
+                                      role="option"
+                                      aria-selected={isSelected}
+                                      onClick={() => {
+                                        handleTargetIdChange(String(target.target_id || ""));
+                                        setHeroSetPickerOpen(false);
+                                      }}
+                                      className={`flex w-full items-center justify-between gap-2 rounded-lg px-3 py-2 text-left text-sm leading-5 transition-colors ${
+                                        isSelected
+                                          ? "bg-[var(--surface-page)] text-[var(--text-primary)]"
+                                          : "text-[var(--text-secondary)] hover:bg-[var(--surface-page)]/70 hover:text-[var(--text-primary)]"
+                                      }`}
+                                    >
+                                      <span className="min-w-0 flex-1 truncate whitespace-nowrap">{target.name}</span>
+                                      {isSelected ? (
+                                        <span className="shrink-0 text-xs font-medium text-[var(--accent)]">Current</span>
+                                      ) : null}
+                                    </button>
+                                  );
+                                })}
+                              </div>
+                            ) : null}
+                          </div>
+
+                          <div className="space-y-3">
+                            <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-secondary)]">{RIP_COPY.scoreLabel}</p>
+                            <div className="flex items-end gap-2">
+                              <span className="inline-flex items-end gap-1.5 text-5xl font-semibold leading-none tracking-[-0.04em] text-[var(--text-primary)] md:text-6xl">
+                                <span>{displayedTopScore}</span>
+                                <span className="pb-1 text-xs font-medium tracking-normal text-[var(--text-secondary)]">/100</span>
+                                <TrendIndicator trend={trendByMetricKey.ripScore} className="mb-1 md:mb-1.5" />
+                              </span>
+                            </div>
+                            <ScoreMeter score={topScoreRaw} rankTier={summary.pack_tier} />
+                            <div className="flex flex-wrap items-center gap-2">
+                              <RankBadge
+                                rank={summary.pack_tier}
+                                label="Rank"
+                                size="supporting"
+                                title={
+                                  summary.pack_rank === null || summary.pack_rank === undefined
+                                    ? "Rank unavailable"
+                                    : `Rank #${summary.pack_rank}`
+                                }
+                              />
+                              <RecommendationBadge label={recommendationBadge} rankTier={summary.pack_tier} />
+                            </div>
+                          </div>
                         </div>
                       </div>
 
                       <div className="flex min-h-[8.25rem] flex-1 flex-col rounded-xl border border-[var(--border-subtle)] bg-[color:color-mix(in_srgb,var(--surface-page)_78%,transparent)] p-4 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.03),0_8px_20px_rgba(2,6,23,0.12)] backdrop-blur-[2px]">
                         <div className="flex items-start justify-between gap-2">
                           <p className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[color:color-mix(in_srgb,var(--text-primary)_72%,var(--text-secondary))]">Set Value</p>
+                          <InfoPopover text="Simulated set value: one priced copy per unique card identity in this simulation universe. Variant and pattern rows are collapsed, so future canonical checklist pricing may differ." />
                         </div>
-                        <p className="mt-2 text-lg font-bold text-[var(--text-primary)] [text-shadow:0_1px_1px_rgba(2,6,23,0.18)]">{setValueDisplay}</p>
-                        <p className="mt-auto pt-1 text-xs text-[var(--text-secondary)]">Trend coming soon</p>
+                        <p className="mt-2 inline-flex items-center gap-1.5 text-lg font-bold text-[var(--text-primary)] [text-shadow:0_1px_1px_rgba(2,6,23,0.18)]">
+                          <span>{setValueDisplay}</span>
+                          <TrendIndicator trend={trendByMetricKey.setValue} className="translate-y-px" />
+                        </p>
                       </div>
                       </div>
 
@@ -2767,7 +3403,7 @@ export default function RipStatisticsPageClient({
 
                         <div className="grid gap-2.5 sm:grid-cols-2 lg:grid-cols-3">
                           {decisionMetrics.map((metric) => (
-                            <HeroMetricTile key={`set-compact-${metric.label}`} label={metric.label} value={metric.value} />
+                            <HeroMetricTile key={`set-compact-${metric.label}`} label={metric.label} value={metric.value} trend={metric.trend} />
                           ))}
                         </div>
                       </div>
@@ -2775,21 +3411,26 @@ export default function RipStatisticsPageClient({
                   </div>
                 </section>
 
-                <SectionViewTabs
-                  value={setDetailTab}
-                  onChange={setSetDetailTab}
-                  options={[
-                    { value: "cards", label: "Cards" },
-                    { value: "pull-rates", label: "Pull Rates" },
-                    { value: "analytics", label: "Analytics" },
-                  ]}
-                />
+                <div id="set-detail-content" className="scroll-mt-24 md:scroll-mt-28">
+                  <SectionViewTabs
+                    className="mt-2"
+                    value={setDetailTab}
+                    onChange={setSetDetailTab}
+                    variant="primary"
+                    options={[
+                      { value: "cards", label: "Cards" },
+                      { value: "pull-rates", label: "Pull Rates" },
+                      { value: "analytics", label: "Analytics" },
+                    ]}
+                  />
+                </div>
 
                 {setDetailTab === "cards" ? (
-                  <section className="space-y-3 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-panel)]/70 p-4 md:p-5">
+                  <section id="set-detail-cards" className="scroll-mt-24 space-y-5 rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[linear-gradient(180deg,rgba(15,23,42,0.82),rgba(2,6,23,0.68))] p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_22px_54px_rgba(2,6,23,0.28)] backdrop-blur-md md:scroll-mt-28 md:p-6">
                     <SectionViewTabs
                       value={cardsSubTab}
                       onChange={setCardsSubTab}
+                      variant="secondary"
                       options={[
                         { value: "checklist", label: "Checklist" },
                         { value: "simulated-impact", label: "Simulated Impact" },
@@ -2797,7 +3438,7 @@ export default function RipStatisticsPageClient({
                     />
 
                     {cardsSubTab === "checklist" ? (
-                      <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-page)]/45 px-4 py-4">
+                      <div className="min-w-0">
                         {checklistState.status === "loading" ? (
                           <p className="text-sm text-[var(--text-secondary)]">Loading cards...</p>
                         ) : null}
@@ -2822,10 +3463,14 @@ export default function RipStatisticsPageClient({
                         ) : null}
                       </div>
                     ) : (
-                      <SectionCard
-                        title="Simulated Impact"
-                        subtitle="Cards ranked by how much they contribute to the simulated pack value."
-                      >
+                      <div className="min-w-0 space-y-4">
+                        <div>
+                          <h3 className="text-base font-semibold text-[var(--text-primary)]">Simulated Impact</h3>
+                          <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                            Cards ranked by how much they contribute to the simulated pack value.
+                          </p>
+                        </div>
+
                         <InterpretationInsight
                           sectionMeta={topEvDriversMeta}
                           fallbackSummary={collectorFriendlyText(interpretation?.topEvDrivers)}
@@ -2849,13 +3494,13 @@ export default function RipStatisticsPageClient({
                         ) : null}
 
                         <TopEVDriversContent topHits={topHits} meanValue={summary.mean_value} />
-                      </SectionCard>
+                      </div>
                     )}
                   </section>
                 ) : null}
 
                 {setDetailTab === "pull-rates" ? (
-                  <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-panel)]/70 p-4 md:p-5">
+                  <section id="set-detail-pull-rates" className="scroll-mt-24 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-panel)]/70 p-4 md:scroll-mt-28 md:p-5">
                     {pullRateAssumptions ? (
                       <PullRateAssumptionsCard pullRateAssumptions={pullRateAssumptions} embedded />
                     ) : (
@@ -2960,11 +3605,12 @@ export default function RipStatisticsPageClient({
                         </div>
                       </div>
                       <div className="mt-3 flex w-full justify-center">
-                        <div className="relative inline-block leading-none">
+                        <div className="inline-flex items-end gap-1.5 leading-none">
                           <span className="text-[clamp(3.25rem,10vw,5rem)] font-semibold tracking-[-0.04em] text-[var(--text-primary)]">
                             {displayedTopScore}
                           </span>
-                          <span className="pointer-events-none absolute bottom-2 left-full ml-2 text-sm font-medium text-[var(--text-secondary)] sm:bottom-3">/100</span>
+                          <span className="pb-2 text-sm font-medium text-[var(--text-secondary)] sm:pb-3">/100</span>
+                          <TrendIndicator trend={trendByMetricKey.ripScore} className="mb-2 sm:mb-3" />
                         </div>
                       </div>
                       <div className="mt-4 w-full max-w-lg">
@@ -3008,13 +3654,13 @@ export default function RipStatisticsPageClient({
                             </div>
                             <div className="grid gap-2 sm:grid-cols-3">
                               {primaryDecisionMetrics.map((metric) => (
-                                <HeroMetricTile key={metric.label} label={metric.label} value={metric.value} />
+                                <HeroMetricTile key={metric.label} label={metric.label} value={metric.value} trend={metric.trend} />
                               ))}
                             </div>
                             {secondaryDecisionMetrics.length > 0 ? (
                               <div className="mt-3 grid gap-2 sm:grid-cols-2">
                                 {secondaryDecisionMetrics.map((metric) => (
-                                  <HeroMetricTile key={metric.label} label={metric.label} value={metric.value} />
+                                  <HeroMetricTile key={metric.label} label={metric.label} value={metric.value} trend={metric.trend} />
                                 ))}
                               </div>
                             ) : null}
@@ -3032,10 +3678,10 @@ export default function RipStatisticsPageClient({
                             </div>
                             <div className="grid gap-2 sm:grid-cols-2">
                               {primaryDecisionMetrics.map((metric) => (
-                                <HeroMetricTile key={`simple-mobile-${metric.label}`} label={metric.label} value={metric.value} />
+                                <HeroMetricTile key={`simple-mobile-${metric.label}`} label={metric.label} value={metric.value} trend={metric.trend} />
                               ))}
                               {secondaryDecisionMetrics.map((metric) => (
-                                <HeroMetricTile key={`simple-mobile-secondary-${metric.label}`} label={metric.label} value={metric.value} />
+                                <HeroMetricTile key={`simple-mobile-secondary-${metric.label}`} label={metric.label} value={metric.value} trend={metric.trend} />
                               ))}
                             </div>
                           </MobileMetricAccordion>
@@ -3082,7 +3728,8 @@ export default function RipStatisticsPageClient({
                                 key={metric.label}
                                 label={metric.label}
                                 value={metric.value}
-                                infoText={getMetricTooltip(metric.label)}
+                                trend={metric.trend}
+                                infoText={metric.infoText || getMetricTooltip(metric.label)}
                               />
                             ))}
                           </div>
@@ -3105,7 +3752,8 @@ export default function RipStatisticsPageClient({
                                 key={`expert-mobile-${metric.label}`}
                                 label={metric.label}
                                 value={metric.value}
-                                infoText={getMetricTooltip(metric.label)}
+                                trend={metric.trend}
+                                infoText={metric.infoText || getMetricTooltip(metric.label)}
                               />
                             ))}
                           </MobileMetricAccordion>
@@ -3173,12 +3821,13 @@ export default function RipStatisticsPageClient({
             ) : null}
 
             {effectiveViewMode === "expert" ? (
-            <section className="pt-4">
+            <section id={setDetailMode ? "set-detail-analytics" : undefined} className="scroll-mt-24 pt-4 md:scroll-mt-28">
               <div className="grid gap-4 xl:grid-cols-3">
                 {/* Expert pillar metrics: Overview should be user-readable outcomes; Details should prioritize direct score inputs or close precursors. Context rows are allowed only when they clarify pillar behavior. Do not reuse hero Score Details mappings for pillar Details without ownership audit. */}
                 <ScorePillarCard
                   title="Profit"
                   score={displayedProfitScore}
+                  scoreTrend={trendByMetricKey.profitScore}
                   rankValue={summary.profit_rank}
                   rankTier={summary.profit_tier}
                   rankLabel="Profit Rank"
@@ -3186,22 +3835,23 @@ export default function RipStatisticsPageClient({
                   fallbackSummary={null}
                   infoText={getFormattedTooltip("Profit")}
                   simpleMetrics={[
-                    { label: RIP_COPY.simpleMetrics.currentPackCost, value: formatCurrency(summary.pack_cost) },
-                    { label: RIP_COPY.simpleMetrics.averagePackValue, value: formatCurrency(summary.mean_value) },
-                    { label: RIP_COPY.simpleMetrics.averageLoss, value: formatSignedCurrency(simpleAverageLossValue) },
-                    { label: RIP_COPY.simpleMetrics.chanceToBeatPackCost, value: formatPercent(summary.prob_profit, { probability: true }) },
-                    { label: RIP_COPY.simpleMetrics.chanceAtBigPull, value: formatPercent(summary.prob_big_hit, { probability: true }) },
+                    { label: RIP_COPY.simpleMetrics.currentPackCost, value: formatCurrency(summary.pack_cost), trend: trendByMetricKey.packCost },
+                    { label: RIP_COPY.simpleMetrics.averagePackValue, value: formatCurrency(summary.mean_value), trend: trendByMetricKey.averagePackValue },
+                    { label: RIP_COPY.simpleMetrics.averageLoss, value: formatSignedCurrency(simpleAverageLossValue), trend: trendByMetricKey.averageLoss },
+                    { label: RIP_COPY.simpleMetrics.chanceToBeatPackCost, value: formatPercent(summary.prob_profit, { probability: true }), trend: trendByMetricKey.chanceToBeatPackCost },
+                    { label: RIP_COPY.simpleMetrics.chanceAtBigPull, value: formatPercent(summary.prob_big_hit, { probability: true }), trend: trendByMetricKey.chanceAtBigPull },
                   ]}
                   advancedMetrics={[
-                    { label: "Average Return vs Cost", value: formatNumber(meanValueToCostRatio, 2) },
-                    { label: "Typical Return vs Cost", value: formatNumber(medianValueToCostRatio, 2) },
-                    { label: "Big Hit Upside", value: formatNumber(summary.p95_value_to_cost_ratio, 2) },
-                    { label: "God Pull Upside", value: formatNumber(summary.p99_value_to_cost_ratio, 2) },
+                    { label: "Average Return vs Cost", value: formatNumber(meanValueToCostRatio, 2), trend: trendByMetricKey.averageReturnVsCost },
+                    { label: "Typical Return vs Cost", value: formatNumber(medianValueToCostRatio, 2), trend: trendByMetricKey.typicalReturnVsCost },
+                    { label: "Big Hit Upside", value: formatNumber(summary.p95_value_to_cost_ratio, 2), trend: trendByMetricKey.bigHitUpside },
+                    { label: "God Pull Upside", value: formatNumber(summary.p99_value_to_cost_ratio, 2), trend: trendByMetricKey.godPullUpside },
                   ]}
                 />
                 <ScorePillarCard
                   title="Safety"
                   score={displayedSafetyScore}
+                  scoreTrend={trendByMetricKey.safetyScore}
                   rankValue={summary.safety_rank}
                   rankTier={summary.safety_tier}
                   rankLabel="Safety Rank"
@@ -3209,19 +3859,20 @@ export default function RipStatisticsPageClient({
                   fallbackSummary={null}
                   infoText={getFormattedTooltip("Safety")}
                   simpleMetrics={[
-                    { label: "Typical Pack Value", value: formatCurrency(percentileP50 ?? summary.median_value), infoText: getMetricTooltip("Typical Pack Value") },
-                    { label: "Bad Pack Floor Value", value: formatCurrency(percentileP5 ?? summary.tail_value_p05), infoText: getMetricTooltip("Bad Pack Floor Value") },
-                    { label: "Chance to Miss Pack Cost", value: formatPercent(1 - (toNumber(summary.prob_profit) > 1 ? toNumber(summary.prob_profit) / 100 : toNumber(summary.prob_profit)), { probability: true }), infoText: getMetricTooltip("Chance to Miss Pack Cost") },
+                    { label: "Typical Pack Value", value: formatCurrency(percentileP50 ?? summary.median_value), trend: trendByMetricKey.typicalPackValue, infoText: getMetricTooltip("Typical Pack Value") },
+                    { label: "Bad Pack Floor Value", value: formatCurrency(percentileP5 ?? summary.tail_value_p05), trend: trendByMetricKey.badPackFloorValue, infoText: getMetricTooltip("Bad Pack Floor Value") },
+                    { label: "Chance to Miss Pack Cost", value: formatPercent(1 - (toNumber(summary.prob_profit) > 1 ? toNumber(summary.prob_profit) / 100 : toNumber(summary.prob_profit)), { probability: true }), trend: trendByMetricKey.chanceToMissPackCost, infoText: getMetricTooltip("Chance to Miss Pack Cost") },
                   ]}
                   advancedMetrics={[
-                    { label: "Average Loss When You Miss", value: formatLossCurrency(summary.expected_loss_when_losing), infoText: getMetricTooltip("Average Loss When You Miss") },
-                    { label: "Typical Loss When You Miss", value: formatLossCurrency(summary.median_loss_when_losing), infoText: getMetricTooltip("Typical Loss When You Miss") },
-                    { label: "Worst 5% Outcome", value: formatCurrency(percentileP5 ?? summary.tail_value_p05), infoText: getMetricTooltip("Worst 5% Outcome") },
+                    { label: "Average Loss When You Miss", value: formatLossCurrency(summary.expected_loss_when_losing), trend: trendByMetricKey.averageLossWhenYouMiss, infoText: getMetricTooltip("Average Loss When You Miss") },
+                    { label: "Typical Loss When You Miss", value: formatLossCurrency(summary.median_loss_when_losing), trend: trendByMetricKey.typicalLossWhenYouMiss, infoText: getMetricTooltip("Typical Loss When You Miss") },
+                    { label: "Worst 5% Outcome", value: formatCurrency(percentileP5 ?? summary.tail_value_p05), trend: trendByMetricKey.worstFivePercentShortfall?.trend === "unknown" ? trendByMetricKey.badPackFloorValue : trendByMetricKey.worstFivePercentShortfall, infoText: getMetricTooltip("Worst 5% Outcome") },
                   ]}
                 />
                 <ScorePillarCard
                   title="Stability"
                   score={displayedStabilityScore}
+                  scoreTrend={trendByMetricKey.stabilityScore}
                   rankValue={summary.stability_rank}
                   rankTier={summary.stability_tier}
                   rankLabel="Stability Rank"
@@ -3229,16 +3880,16 @@ export default function RipStatisticsPageClient({
                   fallbackSummary={null}
                   infoText={getFormattedTooltip("Stability")}
                   simpleMetrics={[
-                    { label: "Cards Carrying Value", value: formatNumber(summary.effective_chase_count, 2) },
-                    { label: "Top Chase Share", value: formatPercent(summary.top1_ev_share) },
-                    { label: "Value Spread", value: formatNumber(summary.hhi_ev_concentration, 3) },
+                    { label: "Cards Carrying Value", value: formatNumber(summary.effective_chase_count, 2), trend: trendByMetricKey.chaseDepth },
+                    { label: "Top Chase Share", value: formatPercent(summary.top1_ev_share), trend: trendByMetricKey.top1Share },
+                    { label: "Value Spread", value: formatNumber(summary.hhi_ev_concentration, 3), trend: trendByMetricKey.evConcentration },
                   ]}
                   advancedMetrics={[
-                    { label: "Outcome Volatility", value: formatNumber(summary.coefficient_of_variation, 2) },
-                    { label: "Effective Chase Count", value: formatNumber(summary.effective_chase_count, 2) },
-                    { label: "EV Concentration", value: formatNumber(summary.hhi_ev_concentration, 3) },
-                    { label: "Top 3 Share", value: formatPercent(summary.top3_ev_share) },
-                    { label: "Top 5 Share", value: formatPercent(summary.top5_ev_share) },
+                    { label: "Outcome Volatility", value: formatNumber(summary.coefficient_of_variation, 2), trend: trendByMetricKey.outcomeVolatility },
+                    { label: "Effective Chase Count", value: formatNumber(summary.effective_chase_count, 2), trend: trendByMetricKey.chaseDepth },
+                    { label: "EV Concentration", value: formatNumber(summary.hhi_ev_concentration, 3), trend: trendByMetricKey.evConcentration },
+                    { label: "Top 3 Share", value: formatPercent(summary.top3_ev_share), trend: trendByMetricKey.top3Share },
+                    { label: "Top 5 Share", value: formatPercent(summary.top5_ev_share), trend: trendByMetricKey.top5Share },
                   ]}
                 />
               </div>
@@ -3341,13 +3992,14 @@ export default function RipStatisticsPageClient({
                   <>
                     {graphMode === "historical-trend" ? (
                       <div className="mt-4 hidden gap-3 sm:grid-cols-3 lg:grid lg:grid-cols-6">
-                        <StatTile label={RIP_COPY.chartStats.chanceToBeatPackCost} value={formatPercent(summary.prob_profit, { probability: true })} />
-                        <StatTile label={RIP_COPY.chartStats.chanceAtBigPull} value={formatPercent(summary.prob_big_hit, { probability: true })} />
-                        <StatTile label={RIP_COPY.chartStats.typicalPack} value={formatCurrency(percentileP50 ?? summary.median_value)} />
-                        <StatTile label={RIP_COPY.chartStats.bigHitUpside} value={formatMultiplier(summary.p95_value_to_cost_ratio, 1)} />
+                        <StatTile label={RIP_COPY.chartStats.chanceToBeatPackCost} value={formatPercent(summary.prob_profit, { probability: true })} trend={trendByMetricKey.chanceToBeatPackCost} />
+                        <StatTile label={RIP_COPY.chartStats.chanceAtBigPull} value={formatPercent(summary.prob_big_hit, { probability: true })} trend={trendByMetricKey.chanceAtBigPull} />
+                        <StatTile label={RIP_COPY.chartStats.typicalPack} value={formatCurrency(percentileP50 ?? summary.median_value)} trend={trendByMetricKey.typicalPackValue} />
+                        <StatTile label={RIP_COPY.chartStats.bigHitUpside} value={formatMultiplier(summary.p95_value_to_cost_ratio, 1)} trend={trendByMetricKey.bigHitUpside} />
                         <StatTile
                           label={RIP_COPY.chartStats.godPullUpside}
                           value={formatMultiplier(summary.p99_value_to_cost_ratio, 1)}
+                          trend={trendByMetricKey.godPullUpside}
                           infoText={
                             <div className="space-y-1 text-left">
                               <p>Simple: Rare monster-hit outcome compared with pack price.</p>
@@ -3355,20 +4007,21 @@ export default function RipStatisticsPageClient({
                             </div>
                           }
                         />
-                        <StatTile label={RIP_COPY.chartStats.bestPull} value={formatCurrency(summary.max_value)} />
+                        <StatTile label={RIP_COPY.chartStats.bestPull} value={formatCurrency(summary.max_value)} trend={trendByMetricKey.bestPull} />
                       </div>
                     ) : null}
 
                     {graphMode === "historical-trend" ? (
                       <MobileMetricAccordion title="Metrics" defaultOpen={false} className="mt-4">
                         <div className="grid gap-3 sm:grid-cols-2">
-                          <StatTile label={RIP_COPY.chartStats.chanceToBeatPackCost} value={formatPercent(summary.prob_profit, { probability: true })} />
-                          <StatTile label={RIP_COPY.chartStats.chanceAtBigPull} value={formatPercent(summary.prob_big_hit, { probability: true })} />
-                          <StatTile label={RIP_COPY.chartStats.typicalPack} value={formatCurrency(percentileP50 ?? summary.median_value)} />
-                          <StatTile label={RIP_COPY.chartStats.bigHitUpside} value={formatMultiplier(summary.p95_value_to_cost_ratio, 1)} />
+                          <StatTile label={RIP_COPY.chartStats.chanceToBeatPackCost} value={formatPercent(summary.prob_profit, { probability: true })} trend={trendByMetricKey.chanceToBeatPackCost} />
+                          <StatTile label={RIP_COPY.chartStats.chanceAtBigPull} value={formatPercent(summary.prob_big_hit, { probability: true })} trend={trendByMetricKey.chanceAtBigPull} />
+                          <StatTile label={RIP_COPY.chartStats.typicalPack} value={formatCurrency(percentileP50 ?? summary.median_value)} trend={trendByMetricKey.typicalPackValue} />
+                          <StatTile label={RIP_COPY.chartStats.bigHitUpside} value={formatMultiplier(summary.p95_value_to_cost_ratio, 1)} trend={trendByMetricKey.bigHitUpside} />
                           <StatTile
                             label={RIP_COPY.chartStats.godPullUpside}
                             value={formatMultiplier(summary.p99_value_to_cost_ratio, 1)}
+                            trend={trendByMetricKey.godPullUpside}
                             infoText={
                               <div className="space-y-1 text-left">
                                 <p>Simple: Rare monster-hit outcome compared with pack price.</p>
@@ -3376,7 +4029,7 @@ export default function RipStatisticsPageClient({
                               </div>
                             }
                           />
-                          <StatTile label={RIP_COPY.chartStats.bestPull} value={formatCurrency(summary.max_value)} />
+                          <StatTile label={RIP_COPY.chartStats.bestPull} value={formatCurrency(summary.max_value)} trend={trendByMetricKey.bestPull} />
                         </div>
                       </MobileMetricAccordion>
                     ) : null}

--- a/frontend/components/explore/packValueHistoryNormalization.mjs
+++ b/frontend/components/explore/packValueHistoryNormalization.mjs
@@ -1,0 +1,233 @@
+function toNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function firstFiniteNumber(raw, keys) {
+  for (const key of keys) {
+    const value = toNumber(raw?.[key]);
+    if (value !== null) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function firstFiniteMetric(raw, keys) {
+  for (const key of keys) {
+    const value = toNumber(raw?.[key]);
+    if (value !== null) {
+      return { key, value };
+    }
+  }
+  return { key: null, value: null };
+}
+
+function resolveDollarValue(explicitValue, ratioValue, packCostValue) {
+  const explicit = toNumber(explicitValue);
+  const ratio = toNumber(ratioValue);
+  const packCost = toNumber(packCostValue);
+
+  if (explicit !== null) {
+    if (ratio !== null && packCost !== null) {
+      const derived = ratio * packCost;
+      if (Math.abs(explicit) < 1e-9 && Math.abs(derived) > 1e-6) {
+        return derived;
+      }
+    }
+    return explicit;
+  }
+
+  if (ratio === null || packCost === null) {
+    return null;
+  }
+
+  return ratio * packCost;
+}
+
+function normalizeReturnMetrics(ratioValue, explicitValue, packCostValue) {
+  const ratio = toNumber(ratioValue);
+  const explicit = toNumber(explicitValue);
+  const packCost = toNumber(packCostValue);
+
+  if (ratio !== null && ratio >= 0) {
+    return {
+      returnValue:
+        explicit !== null && Math.abs(explicit) > 1e-9
+          ? explicit
+          : (packCost !== null && packCost > 0 ? ratio * packCost : null),
+      ratioValue: ratio,
+    };
+  }
+
+  if (explicit !== null) {
+    return {
+      returnValue: explicit,
+      ratioValue: packCost !== null && packCost > 0 ? explicit / packCost : null,
+    };
+  }
+
+  if (ratio === null || ratio < 0) {
+    return {
+      returnValue: null,
+      ratioValue: null,
+    };
+  }
+
+  return {
+    returnValue: packCost !== null && packCost > 0 ? ratio * packCost : null,
+    ratioValue: ratio,
+  };
+}
+
+function isEffectivelyZero(value, epsilon = 1e-6) {
+  const parsed = toNumber(value);
+  return parsed !== null && Math.abs(parsed) <= epsilon;
+}
+
+export function shouldUseSummaryRatioFallback(latestRatio, summaryRatio) {
+  const latest = toNumber(latestRatio);
+  const summary = toNumber(summaryRatio);
+
+  if (summary === null || isEffectivelyZero(summary)) {
+    return false;
+  }
+
+  if (latest === null) {
+    return true;
+  }
+
+  return isEffectivelyZero(latest);
+}
+
+export function patchLatestHistoryRowWithSummaryRatios(
+  latestRow,
+  { meanRatioSummary = null, medianRatioSummary = null, effectivePackCost = null } = {}
+) {
+  const useSummaryMeanRatio = shouldUseSummaryRatioFallback(latestRow?.meanCostRatio, meanRatioSummary);
+  const useSummaryMedianRatio = shouldUseSummaryRatioFallback(latestRow?.medianCostRatio, medianRatioSummary);
+
+  const resolvedMeanRatio = useSummaryMeanRatio ? toNumber(meanRatioSummary) : toNumber(latestRow?.meanCostRatio);
+  const resolvedMedianRatio = useSummaryMedianRatio ? toNumber(medianRatioSummary) : toNumber(latestRow?.medianCostRatio);
+  const resolvedPackCost = toNumber(effectivePackCost);
+
+  return {
+    ...latestRow,
+    meanCostRatio: resolvedMeanRatio,
+    medianCostRatio: resolvedMedianRatio,
+    meanValue: useSummaryMeanRatio
+      ? (resolvedMeanRatio !== null && resolvedPackCost !== null ? resolvedMeanRatio * resolvedPackCost : null)
+      : (latestRow?.meanValue ??
+        (resolvedMeanRatio !== null && resolvedPackCost !== null ? resolvedMeanRatio * resolvedPackCost : null)),
+    medianValue: useSummaryMedianRatio
+      ? (resolvedMedianRatio !== null && resolvedPackCost !== null ? resolvedMedianRatio * resolvedPackCost : null)
+      : (latestRow?.medianValue ??
+        (resolvedMedianRatio !== null && resolvedPackCost !== null ? resolvedMedianRatio * resolvedPackCost : null)),
+  };
+}
+
+export function normalizeHistoryTrendPoint(raw, index, fallbackPackCost) {
+  const meanRatioMetric = firstFiniteMetric(raw, [
+    "mean_value_to_cost_ratio",
+    "meanValueToCostRatio",
+    "average_return_vs_cost",
+    "averageReturnVsCost",
+    "mean_cost_ratio",
+    "meanCostRatio",
+    "average_return_ratio",
+    "averageReturnRatio",
+    "simulated_mean_value_to_cost_ratio",
+    "simulatedMeanValueToCostRatio",
+    "simulated_mean_pack_value_vs_pack_cost",
+    "simulatedMeanPackValueVsPackCost",
+  ]);
+  const medianRatioMetric = firstFiniteMetric(raw, [
+    "median_value_to_cost_ratio",
+    "medianValueToCostRatio",
+    "typical_return_vs_cost",
+    "typicalReturnVsCost",
+    "typical_value_to_cost_ratio",
+    "typicalValueToCostRatio",
+    "median_cost_ratio",
+    "medianCostRatio",
+    "typical_return_ratio",
+    "typicalReturnRatio",
+    "simulated_median_value_to_cost_ratio",
+    "simulatedMedianValueToCostRatio",
+    "simulated_median_pack_value_vs_pack_cost",
+    "simulatedMedianPackValueVsPackCost",
+  ]);
+  const p95CostRatio = firstFiniteNumber(raw, [
+    "p95_value_to_cost_ratio",
+    "p95ValueToCostRatio",
+    "p95_cost_ratio",
+    "p95CostRatio",
+    "big_hit_upside_ratio",
+    "bigHitUpsideRatio",
+  ]);
+  const packCostValue = firstFiniteNumber(raw, ["pack_cost", "packCost", "cost"]) ?? toNumber(fallbackPackCost);
+
+  const meanValueDirect = firstFiniteNumber(raw, [
+    "average_pack_value",
+    "averagePackValue",
+    "simulated_mean_pack_value",
+    "simulatedMeanPackValue",
+    "mean_pack_value",
+    "meanPackValue",
+    "mean_value",
+    "meanValue",
+  ]);
+  const medianValueDirect = firstFiniteNumber(raw, [
+    "typical_pack_value",
+    "typicalPackValue",
+    "simulated_median_pack_value",
+    "simulatedMedianPackValue",
+    "median_pack_value",
+    "medianPackValue",
+    "median_value",
+    "medianValue",
+  ]);
+  const p95ValueDirect = firstFiniteNumber(raw, [
+    "big_hit_value",
+    "bigHitValue",
+    "simulated_p95_pack_value",
+    "simulatedP95PackValue",
+    "p95_pack_value",
+    "p95PackValue",
+    "p95_value",
+    "p95Value",
+  ]);
+
+  const meanRatioRaw =
+    (meanRatioMetric.key === "simulated_mean_pack_value_vs_pack_cost" ||
+      meanRatioMetric.key === "simulatedMeanPackValueVsPackCost") &&
+    meanRatioMetric.value === 0 &&
+    meanValueDirect === null
+      ? null
+      : meanRatioMetric.value;
+  const medianRatioRaw =
+    (medianRatioMetric.key === "simulated_median_pack_value_vs_pack_cost" ||
+      medianRatioMetric.key === "simulatedMedianPackValueVsPackCost") &&
+    medianRatioMetric.value === 0 &&
+    medianValueDirect === null
+      ? null
+      : medianRatioMetric.value;
+
+  const normalizedMean = normalizeReturnMetrics(meanRatioRaw, meanValueDirect, packCostValue);
+  const normalizedMedian = normalizeReturnMetrics(medianRatioRaw, medianValueDirect, packCostValue);
+
+  return {
+    id: `${index}:${raw?.snapshot_date || raw?.snapshotDate || "na"}:${raw?.calculation_run_id || raw?.calculationRunId || "na"}`,
+    rawPoint: raw,
+    snapshotDate: raw?.snapshot_date || raw?.snapshotDate || null,
+    runCreatedAt: raw?.run_created_at || raw?.runCreatedAt || null,
+    calculationRunId: raw?.calculation_run_id || raw?.calculationRunId || null,
+    packCost: packCostValue,
+    meanCostRatio: normalizedMean.ratioValue,
+    medianCostRatio: normalizedMedian.ratioValue,
+    p95CostRatio,
+    meanValue: normalizedMean.returnValue,
+    medianValue: normalizedMedian.returnValue,
+    p95Value: resolveDollarValue(p95ValueDirect, p95CostRatio, packCostValue),
+  };
+}

--- a/frontend/components/explore/packValueHistoryNormalization.test.mjs
+++ b/frontend/components/explore/packValueHistoryNormalization.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  normalizeHistoryTrendPoint,
+  patchLatestHistoryRowWithSummaryRatios,
+  shouldUseSummaryRatioFallback,
+} from "./packValueHistoryNormalization.mjs";
+
+test("shouldUseSummaryRatioFallback returns true for null or zero latest ratio when summary ratio is non-zero", () => {
+  assert.equal(shouldUseSummaryRatioFallback(null, 1.23), true);
+  assert.equal(shouldUseSummaryRatioFallback(0, 1.23), true);
+  assert.equal(shouldUseSummaryRatioFallback(0.0000002, 1.23), true);
+  assert.equal(shouldUseSummaryRatioFallback(0.84, 1.23), false);
+  assert.equal(shouldUseSummaryRatioFallback(0, 0), false);
+});
+
+test("patchLatestHistoryRowWithSummaryRatios uses summary mean/median ratios when latest historical ratios are zero placeholders", () => {
+  const latestRow = {
+    snapshotDate: "2026-06-09",
+    meanCostRatio: 0,
+    medianCostRatio: 0,
+    meanValue: 0,
+    medianValue: 0,
+    p95CostRatio: 2.78,
+    p95Value: 82.0,
+  };
+
+  const patched = patchLatestHistoryRowWithSummaryRatios(latestRow, {
+    meanRatioSummary: 0.5,
+    medianRatioSummary: 0.133,
+    effectivePackCost: 29.47,
+  });
+
+  assert.equal(patched.meanCostRatio, 0.5);
+  assert.equal(patched.medianCostRatio, 0.133);
+  assert.ok(Math.abs(patched.meanValue - 14.735) < 0.001);
+  assert.ok(Math.abs(patched.medianValue - 3.91951) < 0.001);
+  assert.equal(patched.p95CostRatio, 2.78);
+  assert.equal(patched.p95Value, 82.0);
+});
+
+test("normalizeHistoryTrendPoint resolves camelCase historical fields", () => {
+  const point = normalizeHistoryTrendPoint(
+    {
+      snapshotDate: "2026-06-09",
+      calculationRunId: "run-123",
+      runCreatedAt: "2026-06-09T17:15:58.820087+00:00",
+      packCost: 29.47,
+      meanValueToCostRatio: 0.5,
+      medianValueToCostRatio: 0.133,
+      p95ValueToCostRatio: 2.7883,
+    },
+    0,
+    null
+  );
+
+  assert.equal(point.snapshotDate, "2026-06-09");
+  assert.equal(point.calculationRunId, "run-123");
+  assert.equal(point.meanCostRatio, 0.5);
+  assert.equal(point.medianCostRatio, 0.133);
+  assert.equal(point.p95CostRatio, 2.7883);
+});
+
+test("normalizeHistoryTrendPoint resolves snake_case historical fields", () => {
+  const point = normalizeHistoryTrendPoint(
+    {
+      snapshot_date: "2026-06-05",
+      calculation_run_id: "run-456",
+      run_created_at: "2026-06-05T17:15:58.820087+00:00",
+      pack_cost: 29.47,
+      mean_value_to_cost_ratio: 0.494,
+      median_value_to_cost_ratio: 0.1282,
+      p95_value_to_cost_ratio: 2.8173,
+    },
+    1,
+    null
+  );
+
+  assert.equal(point.snapshotDate, "2026-06-05");
+  assert.equal(point.calculationRunId, "run-456");
+  assert.equal(point.meanCostRatio, 0.494);
+  assert.equal(point.medianCostRatio, 0.1282);
+  assert.equal(point.p95CostRatio, 2.8173);
+});

--- a/frontend/lib/explore/interpretationTone.js
+++ b/frontend/lib/explore/interpretationTone.js
@@ -33,47 +33,62 @@ const TIER_TO_TONE_KEY = {
 const TONE_PALETTE = {
   elite: {
     accentColor: "rgba(192,132,252,0.96)",
-    borderColor: "rgba(192,132,252,0.58)",
-    textColor: "rgba(240,216,255,0.98)",
+    borderColor: "rgba(192,132,252,0.22)",
+    textColor: "rgba(192,132,252,0.86)",
     softBackground: "rgba(39,18,57,0.52)",
-    badgeBackground: "rgba(44,20,66,0.88)",
+    badgeBackground: "rgba(2,8,23,0.58)",
   },
   strong: {
     accentColor: "rgba(45,212,191,0.96)",
-    borderColor: "rgba(45,212,191,0.54)",
-    textColor: "rgba(167,243,208,0.98)",
+    borderColor: "rgba(45,212,191,0.22)",
+    textColor: "rgba(45,212,191,0.86)",
     softBackground: "rgba(10,37,37,0.52)",
-    badgeBackground: "rgba(8,43,42,0.88)",
+    badgeBackground: "rgba(2,8,23,0.58)",
   },
   solid: {
     accentColor: "rgba(134,239,172,0.96)",
-    borderColor: "rgba(134,239,172,0.52)",
-    textColor: "rgba(220,252,231,0.98)",
+    borderColor: "rgba(134,239,172,0.22)",
+    textColor: "rgba(134,239,172,0.86)",
     softBackground: "rgba(14,42,26,0.52)",
-    badgeBackground: "rgba(11,46,25,0.88)",
+    badgeBackground: "rgba(2,8,23,0.58)",
   },
   caution: {
     accentColor: "rgba(251,146,60,0.96)",
-    borderColor: "rgba(251,146,60,0.54)",
-    textColor: "rgba(254,215,170,0.98)",
+    borderColor: "rgba(251,146,60,0.22)",
+    textColor: "rgba(251,146,60,0.86)",
     softBackground: "rgba(58,30,10,0.52)",
-    badgeBackground: "rgba(62,31,8,0.88)",
+    badgeBackground: "rgba(2,8,23,0.58)",
   },
   danger: {
     accentColor: "rgba(251,113,133,0.96)",
-    borderColor: "rgba(251,113,133,0.54)",
-    textColor: "rgba(254,205,211,0.98)",
+    borderColor: "rgba(251,113,133,0.22)",
+    textColor: "rgba(251,113,133,0.86)",
     softBackground: "rgba(58,19,28,0.52)",
-    badgeBackground: "rgba(62,16,28,0.88)",
+    badgeBackground: "rgba(2,8,23,0.58)",
   },
   neutral: {
     accentColor: "rgba(125,211,252,0.96)",
-    borderColor: "rgba(125,211,252,0.5)",
-    textColor: "rgba(219,234,254,0.98)",
+    borderColor: "rgba(125,211,252,0.22)",
+    textColor: "rgba(125,211,252,0.86)",
     softBackground: "rgba(22,36,55,0.5)",
-    badgeBackground: "rgba(20,39,62,0.88)",
+    badgeBackground: "rgba(2,8,23,0.58)",
   },
 };
+
+function getRankTonePalette(tier, fallbackPalette) {
+  const rankColor = RANK_CONFIG[tier]?.color;
+  if (!rankColor) {
+    return fallbackPalette;
+  }
+
+  return {
+    accentColor: withAlpha(rankColor, 0.96),
+    borderColor: withAlpha(rankColor, 0.22),
+    textColor: withAlpha(rankColor, 0.86),
+    softBackground: withAlpha(rankColor, 0.14),
+    badgeBackground: "rgba(2,8,23,0.58)",
+  };
+}
 
 function resolveToneKey({ label, rankTier, severity }) {
   const normalizedTier = normalizeTier(rankTier);
@@ -132,7 +147,8 @@ export function getTierTone(rankTier) {
   }
 
   const toneKey = TIER_TO_TONE_KEY[tier] || "neutral";
-  const palette = TONE_PALETTE[toneKey] || TONE_PALETTE.neutral;
+  const basePalette = TONE_PALETTE[toneKey] || TONE_PALETTE.neutral;
+  const palette = getRankTonePalette(tier, basePalette);
   const tierConfig = RANK_CONFIG[tier] || null;
 
   return {
@@ -167,7 +183,7 @@ export function getInterpretationTone({ label, rankTier, severity } = {}) {
     badgeBorderColor: borderColor,
     badgeTextColor: textColor,
     dotColor: accentColor,
-    glowColor: withAlpha(accentColor, 0.28),
+    glowColor: withAlpha(accentColor, 0.18),
     panelShadow: `0 0 18px ${withAlpha(accentColor, 0.14)}`,
   };
 }
@@ -178,7 +194,7 @@ export function getInterpretationBadgeStyle({ label, rankTier, severity } = {}) 
     background: tone.badgeBackground,
     borderColor: tone.badgeBorderColor,
     color: tone.badgeTextColor,
-    boxShadow: `0 0 12px ${tone.glowColor}`,
+    boxShadow: `0 0 5px 0px ${tone.glowColor}, inset 0 0 4px ${withAlpha(tone.accentColor, 0.03)}`,
   };
 }
 

--- a/frontend/lib/explore/ripStatisticsRouting.js
+++ b/frontend/lib/explore/ripStatisticsRouting.js
@@ -1,0 +1,66 @@
+import { toSetSlug as toCanonicalSetSlug } from "@/utils/slugify";
+
+const TCG_SETS_BASE_PATH = "/TCGs/Pokemon/Sets";
+
+function normaliseString(value) {
+  return String(value || "").trim();
+}
+
+export function toSetSlug(name, fallback = "") {
+  return toCanonicalSetSlug(normaliseString(name), normaliseString(fallback));
+}
+
+export function buildTcgSetHrefFromTarget(target) {
+  const targetType = normaliseString(target?.target_type).toLowerCase();
+  if (targetType !== "set") {
+    return "/Explore/rip-statistics";
+  }
+
+  const slug = toSetSlug(target?.name, target?.target_id);
+  if (!slug) {
+    return "/Explore/rip-statistics";
+  }
+
+  return `${TCG_SETS_BASE_PATH}/${encodeURIComponent(slug)}`;
+}
+
+export function findTargetBySetSlug(targets, setSlug) {
+  const resolvedSlug = normaliseString(setSlug).toLowerCase();
+  if (!resolvedSlug) {
+    return null;
+  }
+
+  const collection = Array.isArray(targets) ? targets : [];
+
+  const slugMatch = collection.find((target) => {
+    if (normaliseString(target?.target_type).toLowerCase() !== "set") {
+      return false;
+    }
+    const targetSlug = toSetSlug(target?.name, target?.target_id);
+    return targetSlug === resolvedSlug;
+  });
+
+  if (slugMatch) {
+    return slugMatch;
+  }
+
+  return (
+    collection.find(
+      (target) =>
+        normaliseString(target?.target_type).toLowerCase() === "set" &&
+        normaliseString(target?.target_id).toLowerCase() === resolvedSlug
+    ) || null
+  );
+}
+
+export function buildTargetHrefById(targets) {
+  const hrefById = {};
+  (Array.isArray(targets) ? targets : []).forEach((target) => {
+    const targetId = normaliseString(target?.target_id);
+    if (!targetId) {
+      return;
+    }
+    hrefById[targetId] = buildTcgSetHrefFromTarget(target);
+  });
+  return hrefById;
+}

--- a/frontend/lib/pokemon/pokemonSetCardsClient.js
+++ b/frontend/lib/pokemon/pokemonSetCardsClient.js
@@ -1,0 +1,65 @@
+function toOptionalString(value) {
+  const text = String(value || "").trim();
+  return text || null;
+}
+
+function toOptionalNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizePayload(payload) {
+  const cards = Array.isArray(payload?.cards) ? payload.cards : [];
+
+  return {
+    set: {
+      id: toOptionalString(payload?.set?.id),
+      name: toOptionalString(payload?.set?.name),
+      slug: toOptionalString(payload?.set?.slug),
+    },
+    cards: cards.map((card) => ({
+      id: toOptionalString(card?.id),
+      name: toOptionalString(card?.name),
+      setId: toOptionalString(card?.set_id ?? card?.setId),
+      setName: toOptionalString(card?.set_name ?? card?.setName),
+      cardNumber: toOptionalString(card?.card_number ?? card?.collector_number ?? card?.number),
+      rarity: toOptionalString(card?.rarity),
+      imageSmallUrl: toOptionalString(card?.image_small_url ?? card?.small_image_url),
+      imageLargeUrl: toOptionalString(card?.image_large_url ?? card?.large_image_url),
+      marketPrice: toOptionalNumber(card?.market_price ?? card?.estimated_market_price),
+      tcgplayerProductId: toOptionalString(card?.tcgplayer_product_id),
+    })),
+    meta: payload?.meta || { dedupe: {}, sources: {}, timings: {} },
+  };
+}
+
+export async function getPokemonSetCards(setId) {
+  const resolvedSetId = String(setId || "").trim();
+  if (!resolvedSetId) {
+    throw new Error("Set id is required");
+  }
+
+  const response = await fetch(
+    `/api/tcgs/pokemon/sets/${encodeURIComponent(resolvedSetId)}/cards`,
+    {
+      method: "GET",
+      cache: "no-store",
+    }
+  );
+
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+
+  if (!response.ok) {
+    const message = payload?.message || payload?.error || "Unable to load set cards";
+    const requestError = new Error(message);
+    requestError.status = response.status;
+    throw requestError;
+  }
+
+  return normalizePayload(payload);
+}

--- a/frontend/lib/pokemon/pokemonSetsServer.js
+++ b/frontend/lib/pokemon/pokemonSetsServer.js
@@ -1,0 +1,94 @@
+import { cache } from "react";
+import { getBackendApiBaseUrl } from "@/lib/runtimeUrls";
+
+const BACKEND_URL = getBackendApiBaseUrl();
+
+const SUCCESS_TTL_MS = 120_000;
+const NOT_FOUND_TTL_MS = 10_000;
+
+const setsCache = new Map();
+const inflightRequests = new Map();
+
+function toCacheKey() {
+  return "pokemon-sets-catalog";
+}
+
+function toOptionalString(value) {
+  const text = String(value || "").trim();
+  return text || null;
+}
+
+function toOptionalNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalisePayload(payload) {
+  const sets = Array.isArray(payload?.sets) ? payload.sets : [];
+
+  return {
+    sets: sets.map((setSummary) => ({
+      id: toOptionalString(setSummary?.id),
+      name: toOptionalString(setSummary?.name),
+      slug: toOptionalString(setSummary?.slug),
+      era: toOptionalString(setSummary?.era),
+      series: toOptionalString(setSummary?.series),
+      releaseDate: toOptionalString(setSummary?.release_date ?? setSummary?.releaseDate),
+      cardCount: toOptionalNumber(setSummary?.card_count ?? setSummary?.cardCount),
+      setCode: toOptionalString(setSummary?.set_code ?? setSummary?.setCode),
+      logoUrl: toOptionalString(setSummary?.logo_url ?? setSummary?.logoUrl),
+      symbolUrl: toOptionalString(setSummary?.symbol_url ?? setSummary?.symbolUrl),
+      imageUrl: toOptionalString(setSummary?.image_url ?? setSummary?.imageUrl),
+    })),
+    meta: payload?.meta || { warnings: [], timings: {}, sources: {} },
+  };
+}
+
+const _fetchPokemonSets = cache(async function _fetchPokemonSets() {
+  const cacheKey = toCacheKey();
+  const now = Date.now();
+
+  const cached = setsCache.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    return cached.data;
+  }
+
+  if (inflightRequests.has(cacheKey)) {
+    return inflightRequests.get(cacheKey);
+  }
+
+  const promise = (async () => {
+    const url = `${BACKEND_URL}/tcgs/pokemon/sets`;
+    const res = await fetch(url, { cache: "no-store" });
+
+    if (res.status === 404) {
+      const emptyPayload = normalisePayload(null);
+      setsCache.set(cacheKey, {
+        data: emptyPayload,
+        expiresAt: now + NOT_FOUND_TTL_MS,
+      });
+      return emptyPayload;
+    }
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`Pokemon sets backend error ${res.status}: ${body}`);
+    }
+
+    const payload = normalisePayload(await res.json());
+    setsCache.set(cacheKey, {
+      data: payload,
+      expiresAt: now + SUCCESS_TTL_MS,
+    });
+    return payload;
+  })().finally(() => {
+    inflightRequests.delete(cacheKey);
+  });
+
+  inflightRequests.set(cacheKey, promise);
+  return promise;
+});
+
+export async function getPokemonSets() {
+  return _fetchPokemonSets();
+}

--- a/frontend/utils/slugify.js
+++ b/frontend/utils/slugify.js
@@ -9,3 +9,22 @@ export function slugify(text) {
       .replace(/^-+/, "") // Trim - from start of text
       .replace(/-+$/, ""); // Trim - from end of text
   }
+
+export function toSetSlug(value, fallback = "") {
+  const primary = String(value || "").trim();
+  const fallbackValue = String(fallback || "").trim();
+  const raw = primary || fallbackValue;
+
+  if (!raw) {
+    return "";
+  }
+
+  return raw
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "");
+}


### PR DESCRIPTION
…d value contribution analysis

- Added functionality to fetch and display a checklist of cards for specific Pokémon sets.
- Introduced new metrics including average hit value and set value in the statistics overview.
- Implemented routing utilities for generating set slugs and building target URLs.
- Created a new API client for fetching Pokémon set cards with proper payload normalization.
- Enhanced the UI to support detailed views for card contributions and pull rates.
- Updated slugify utility to handle set slugs more effectively.